### PR TITLE
Fix consulta edit form display and receta date

### DIFF
--- a/consultorio_API/forms.py
+++ b/consultorio_API/forms.py
@@ -987,8 +987,8 @@ class RecetaForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Establecer fecha por defecto (30 días desde hoy)
-        if not self.instance.pk:
+        # Establecer fecha por defecto (30 días desde hoy) si no existe
+        if not self.instance.pk or not self.instance.valido_hasta:
             self.fields['valido_hasta'].initial = timezone.now().date() + timedelta(days=30)
 
 

--- a/consultorio_API/views.py
+++ b/consultorio_API/views.py
@@ -2367,8 +2367,7 @@ class ConsultaUpdateView(NextRedirectMixin, LoginRequiredMixin, ConsultaPermisoM
     template_name = 'PAGES/consultas/editar.html'
 
     def get_form_class(self):
-        if self.get_object().tipo == 'sin_cita':
-            return ConsultaSinCitaForm
+        """Use the medical form for editing regardless of tipo."""
         return ConsultaMedicoForm
 
     def _get_return_to(self):


### PR DESCRIPTION
## Summary
- show medical form on consulta edit regardless of consultation type
- default receta `valido_hasta` when missing

## Testing
- `python -m pip install -r requirements.txt`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_687b076d594c8324ba51e74ba38fe66c