### PR TITLE
Fix consulta edit form display and receta date

### DIFF
--- a/consultorio_API/forms.py
+++ b/consultorio_API/forms.py
@@ -987,8 +987,8 @@ class RecetaForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Establecer fecha por defecto (30 días desde hoy)
-        if not self.instance.pk:
+        # Establecer fecha por defecto (30 días desde hoy) si no existe
+        if not self.instance.pk or not self.instance.valido_hasta:
             self.fields['valido_hasta'].initial = timezone.now().date() + timedelta(days=30)
 
 

--- a/consultorio_API/views.py
+++ b/consultorio_API/views.py
@@ -2099,9 +2099,8 @@ class ConsultaSinCitaCreateView(NextRedirectMixin, LoginRequiredMixin, CreateVie
     success_url = reverse_lazy('consultas_lista')
 
     def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs['user'] = self.request.user
-        return kwargs
+        """Return form kwargs without extra user param."""
+        return super().get_form_kwargs()
 
     def form_valid(self, form):
         user = self.request.user
@@ -2367,8 +2366,7 @@ class ConsultaUpdateView(NextRedirectMixin, LoginRequiredMixin, ConsultaPermisoM
     template_name = 'PAGES/consultas/editar.html'
 
     def get_form_class(self):
-        if self.get_object().tipo == 'sin_cita':
-            return ConsultaSinCitaForm
+        """Use the medical form for editing regardless of tipo."""
         return ConsultaMedicoForm
 
     def _get_return_to(self):
@@ -2425,9 +2423,8 @@ class ConsultaUpdateView(NextRedirectMixin, LoginRequiredMixin, ConsultaPermisoM
         return ctx
 
     def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs['user'] = self.request.user
-        return kwargs
+        """Return form kwargs without passing current user."""
+        return super().get_form_kwargs()
 
     def form_valid(self, form):
         consulta = form.save(commit=False)


### PR DESCRIPTION
## Summary
- show medical form on consulta edit regardless of consultation type
- default receta `valido_hasta` when missing
- stop passing `user` arg to consulta edit form

## Testing
- `python -m pip install -r requirements.txt`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_687b076d594c8324ba51e74ba38fe66c