### PR TITLE
Implement per-role consultorio assignment for patients

### DIFF
--- a/consultorio_API/forms.py
+++ b/consultorio_API/forms.py
@@ -222,10 +222,10 @@ class PacienteForm(forms.ModelForm):
                 'class': 'form-control',
                 'placeholder': 'Nombre completo del paciente'
             }),
-            'fecha_nacimiento': forms.DateInput(attrs={
-                'type': 'date',
-                'class': 'form-control'
-            }),
+            'fecha_nacimiento': forms.DateInput(
+                format='%Y-%m-%d',
+                attrs={'type': 'date', 'class': 'form-control'}
+            ),
             'sexo': forms.Select(attrs={'class': 'form-select'}),
             'telefono': forms.TextInput(attrs={
                 'class': 'form-control',
@@ -259,19 +259,25 @@ class PacienteForm(forms.ModelForm):
             'foto': 'Foto del Paciente',
         }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, user: Usuario | None = None, **kwargs):
         super().__init__(*args, **kwargs)
-        
+
         # Filtrar solo usuarios que son médicos o asistentes para consultorio_asignado
         self.fields['consultorio_asignado'].queryset = Usuario.objects.filter(
-            rol__in=['medico', 'asistente'], 
+            rol__in=['medico', 'asistente'],
             is_active=True
         )
         self.fields['consultorio_asignado'].empty_label = 'Sin asignar'
-        
+
         # Hacer la foto opcional
         self.fields['foto'].required = False
         self.fields['consultorio_asignado'].required = False
+
+        if user and user.rol == 'medico':
+            self.fields['consultorio_asignado'].widget = forms.HiddenInput()
+            self.fields['consultorio_asignado'].initial = user
+        elif user and user.rol != 'admin':
+            self.fields['consultorio_asignado'].widget = forms.HiddenInput()
 
 
 

--- a/consultorio_API/views.py
+++ b/consultorio_API/views.py
@@ -513,9 +513,17 @@ class PacienteCreateView(NextRedirectMixin, PacientePermisoMixin, CreateView):
     template_name = "PAGES/pacientes/crear.html"
     success_url = reverse_lazy("pacientes_lista")
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["user"] = self.request.user
+        return kwargs
+
     def form_valid(self, form):
         paciente = form.save(commit=False)
-        paciente.consultorio_asignado = self.request.user
+        if self.request.user.rol == "medico":
+            paciente.consultorio_asignado = self.request.user
+        else:
+            paciente.consultorio_asignado = form.cleaned_data.get("consultorio_asignado")
         paciente.save()
         return super().form_valid(form)
 
@@ -530,6 +538,20 @@ class PacienteUpdateView(NextRedirectMixin, PacientePermisoMixin, UpdateView):
     form_class = PacienteForm
     template_name = "PAGES/pacientes/editar.html"
     success_url = reverse_lazy("pacientes_lista")
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["user"] = self.request.user
+        return kwargs
+
+    def form_valid(self, form):
+        paciente = form.save(commit=False)
+        if self.request.user.rol == "medico":
+            paciente.consultorio_asignado = self.request.user
+        else:
+            paciente.consultorio_asignado = form.cleaned_data.get("consultorio_asignado")
+        paciente.save()
+        return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)

--- a/templates/PAGES/pacientes/crear.html
+++ b/templates/PAGES/pacientes/crear.html
@@ -66,6 +66,14 @@
                   <div class="text-danger small">{{ error }}</div>
                 {% endfor %}
               </div>
+              {% if usuario.rol == 'admin' %}
+              <div class="col-md-6 mb-3">
+                {{ form.consultorio_asignado.label_tag }} {{ form.consultorio_asignado }}
+                {% for error in form.consultorio_asignado.errors %}
+                  <div class="text-danger small">{{ error }}</div>
+                {% endfor %}
+              </div>
+              {% endif %}
             </div>
           </div>
         </div>

--- a/templates/PAGES/pacientes/editar.html
+++ b/templates/PAGES/pacientes/editar.html
@@ -67,6 +67,14 @@
                   <div class="text-danger small">{{ error }}</div>
                 {% endfor %}
               </div>
+              {% if usuario.rol == 'admin' %}
+              <div class="col-md-6 mb-3">
+                {{ form.consultorio_asignado.label_tag }} {{ form.consultorio_asignado }}
+                {% for error in form.consultorio_asignado.errors %}
+                  <div class="text-danger small">{{ error }}</div>
+                {% endfor %}
+              </div>
+              {% endif %}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- allow PacienteForm to receive the current user
- hide/assign consultorio automatically for doctors
- show consultorio selector for admins in patient templates
- ensure date of birth is correctly displayed when editing

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687df62ef504832487636405e63935fa