### PR TITLE
Add password edit fields for admin

### DIFF
--- a/consultorio_API/forms.py
+++ b/consultorio_API/forms.py
@@ -1288,9 +1288,11 @@ class UsuarioForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        
+
         # Si es edición, hacer la contraseña opcional
         if self.instance.pk:
+            self.fields['password1'].label = 'Nueva contraseña'
+            self.fields['password2'].label = 'Confirmar contraseña'
             self.fields['password1'].help_text = "Dejar en blanco para mantener la contraseña actual"
             self.fields['password2'].help_text = "Dejar en blanco para mantener la contraseña actual"
 

--- a/templates/PAGES/usuarios/editar.html
+++ b/templates/PAGES/usuarios/editar.html
@@ -71,6 +71,18 @@
                 {% endfor %}
               </div>
               <div class="col-md-6 mb-3">
+                {{ form.password1.label_tag }} {{ form.password1 }}
+                {% for error in form.password1.errors %}
+                  <div class="text-danger small">{{ error }}</div>
+                {% endfor %}
+              </div>
+              <div class="col-md-6 mb-3">
+                {{ form.password2.label_tag }} {{ form.password2 }}
+                {% for error in form.password2.errors %}
+                  <div class="text-danger small">{{ error }}</div>
+                {% endfor %}
+              </div>
+              <div class="col-md-6 mb-3">
                 {{ form.cedula_profesional.label_tag }} {{ form.cedula_profesional }}
                 {% for error in form.cedula_profesional.errors %}
                   <div class="text-danger small">{{ error }}</div>


### PR DESCRIPTION
## Summary
- allow admin to set a new password when editing a user
- show password fields in the edit template

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687df65b3b108324aa27675f7a5dcc2b