### PR TITLE
Mostrar fecha en recetas y PDF

### DIFF
--- a/consultorio_API/forms.py
+++ b/consultorio_API/forms.py
@@ -222,10 +222,13 @@ class PacienteForm(forms.ModelForm):
                 'class': 'form-control',
                 'placeholder': 'Nombre completo del paciente'
             }),
-            'fecha_nacimiento': forms.DateInput(attrs={
-                'type': 'date',
-                'class': 'form-control'
-            }),
+            'fecha_nacimiento': forms.DateInput(
+                format='%Y-%m-%d',
+                attrs={
+                    'type': 'date',
+                    'class': 'form-control'
+                }
+            ),
             'sexo': forms.Select(attrs={'class': 'form-select'}),
             'telefono': forms.TextInput(attrs={
                 'class': 'form-control',
@@ -268,10 +271,13 @@ class PacienteForm(forms.ModelForm):
             is_active=True
         )
         self.fields['consultorio_asignado'].empty_label = 'Sin asignar'
-        
+
         # Hacer la foto opcional
         self.fields['foto'].required = False
         self.fields['consultorio_asignado'].required = False
+
+        # Asegurar formato ISO para el input de fecha
+        self.fields['fecha_nacimiento'].input_formats = ['%Y-%m-%d']
 
 
 

--- a/templates/PAGES/pacientes/detalle.html
+++ b/templates/PAGES/pacientes/detalle.html
@@ -400,6 +400,10 @@
                           <span class="badge bg-success">
                             <i class="bi bi-file-earmark-medical me-1"></i>Emitida
                           </span>
+                          <br>
+                          <small class="text-muted">
+                            {{ c.receta.fecha_emision|date:"d/m/Y" }}
+                          </small>
                         {% else %}
                           <span class="badge bg-secondary">
                             <i class="bi bi-dash-circle me-1"></i>Sin receta

--- a/templates/PAGES/pdf/paciente_historial.html
+++ b/templates/PAGES/pdf/paciente_historial.html
@@ -103,7 +103,7 @@
             <p><strong>Tratamiento:</strong> {{ consulta.tratamiento|default:"-" }}</p>
             <p><strong>Observaciones:</strong> {{ consulta.observaciones|default:"-" }}</p>
             {% if consulta.receta %}
-              <p><strong>Receta:</strong></p>
+              <p><strong>Receta ({{ consulta.receta.fecha_emision|date:"d/m/Y" }}):</strong></p>
               <ul>
                 {% for med in consulta.receta.medicamentos.all %}
                   <li>{{ med.nombre }} - {{ med.dosis }} ({{ med.frecuencia }})</li>

--- a/templates/PAGES/pdf/receta_consulta.html
+++ b/templates/PAGES/pdf/receta_consulta.html
@@ -281,7 +281,7 @@
         <div class="doctor-date-box bordered-box">
             <div class="info-row">
                 <div class="info-field">
-                    <span class="label">Fecha:</span> {{ consulta.receta.fecha_emision|date:"d/m/Y" }}
+                    <span class="label">Fecha de emisión:</span> {{ consulta.receta.fecha_emision|date:"d/m/Y" }}
                 </div>
                 <div class="info-field" style="text-align: right;">
                     <span class="label">Válido hasta:</span> {{ consulta.receta.valido_hasta|date:"d/m/Y"|default:"___" }}

--- a/templates/PAGES/recetas/crear.html
+++ b/templates/PAGES/recetas/crear.html
@@ -4,6 +4,9 @@
 {% block content %}
 <div class="container">
   <h3>Receta para {{ consulta.paciente.nombre_completo }}</h3>
+  <p class="text-muted">
+    Fecha de emisión: {{ receta_form.instance.fecha_emision|date:"d/m/Y" }}
+  </p>
   <form method="post">
     {% csrf_token %}
     <div class="mb-3">


### PR DESCRIPTION
## Summary
- display fecha de emisión when creating recetas
- show fecha de emisión in listado de consultas del paciente
- label receta PDF with fecha de emisión
- include fecha de emisión in historial PDF
- fix date widget when editing pacientes

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_687df66daf808324b76c4a7f1c963e3e