### PR TITLE
Add global ?next= redirect support

### DIFF
--- a/consultorio_API/middleware.py
+++ b/consultorio_API/middleware.py
@@ -1,0 +1,17 @@
+from django.http import HttpResponseRedirect
+from django.utils.http import url_has_allowed_host_and_scheme
+
+
+class NextRedirectMiddleware:
+    """Redirect to ?next= after any successful action."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        next_url = request.POST.get('next') or request.GET.get('next')
+        if next_url and isinstance(response, HttpResponseRedirect):
+            if url_has_allowed_host_and_scheme(next_url, allowed_hosts={request.get_host()}):
+                response['Location'] = next_url
+        return response

--- a/consultorio_medico/settings.py
+++ b/consultorio_medico/settings.py
@@ -53,6 +53,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'consultorio_API.middleware.NextRedirectMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'consultorio_API.views.AuditMiddleware',
 ]


### PR DESCRIPTION
## Summary
- create `NextRedirectMiddleware` that redirects to `?next=` if provided
- use the new middleware in Django settings

## Testing
- `pip install -r requirements.txt`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_687df67970fc832490ea16300a4d1474