### PR TITLE
Adjust dashboard links in profile templates

### DIFF
--- a/templates/PAGES/perfil/editar.html
+++ b/templates/PAGES/perfil/editar.html
@@ -17,7 +17,7 @@
                     <nav aria-label="breadcrumb">
                         <ol class="breadcrumb mb-0">
                             <li class="breadcrumb-item">
-                                <a href="{% if usuario.rol == 'admin' %}{% url 'dashboard_admin' %}{% elif usuario.rol == 'medico' %}{% url 'dashboard_medico' %}{% else %}{% url 'dashboard_asistente' %}{% endif %}" class="text-decoration-none">
+                                <a href="{% if usuario.rol == 'admin' %}{% url 'dashboard_admin' %}{% elif usuario.rol == 'medico' %}{% url 'dashboard_medico' %}{% else %}{% url 'citas_lista' %}{% endif %}" class="text-decoration-none">
                                     <i class="bi bi-house-door me-1"></i>Dashboard
                                 </a>
                             </li>
@@ -269,8 +269,11 @@
 
                         <!-- Botones de acción -->
                         <div class="d-flex flex-wrap justify-content-end gap-3 mt-5">
+                            <a href="{% if usuario.rol == 'admin' %}{% url 'dashboard_admin' %}{% elif usuario.rol == 'medico' %}{% url 'dashboard_medico' %}{% else %}{% url 'citas_lista' %}{% endif %}" class="btn btn-outline-secondary btn-lg px-4">
+                                <i class="bi bi-arrow-left me-2"></i>Volver al Dashboard
+                            </a>
                             <a href="{% url 'ver_perfil' %}" class="btn btn-outline-secondary btn-lg px-4">
-                                <i class="bi bi-arrow-left me-2"></i>Cancelar
+                                <i class="bi bi-x-lg me-2"></i>Cancelar
                             </a>
                             <button type="submit" class="btn btn-primary btn-lg px-4 shadow-sm">
                                 <i class="bi bi-check-lg me-2"></i>Guardar Cambios

--- a/templates/PAGES/perfil/ver.html
+++ b/templates/PAGES/perfil/ver.html
@@ -16,7 +16,7 @@
                     <nav aria-label="breadcrumb">
                         <ol class="breadcrumb mb-0">
                             <li class="breadcrumb-item">
-                                <a href="{% if usuario.rol == 'admin' %}{% url 'dashboard_admin' %}{% elif usuario.rol == 'medico' %}{% url 'dashboard_medico' %}{% else %}{% url 'dashboard_asistente' %}{% endif %}" class="text-decoration-none">
+                                <a href="{% if usuario.rol == 'admin' %}{% url 'dashboard_admin' %}{% elif usuario.rol == 'medico' %}{% url 'dashboard_medico' %}{% else %}{% url 'citas_lista' %}{% endif %}" class="text-decoration-none">
                                     <i class="bi bi-house-door me-1"></i>Dashboard
                                 </a>
                             </li>
@@ -192,7 +192,7 @@
                             <a href="{% url 'editar_perfil' %}" class="btn btn-primary btn-lg px-4 shadow-sm">
                                 <i class="bi bi-pencil-square me-2"></i>Editar Perfil
                             </a>
-                            <a href="{% if usuario.rol == 'admin' %}{% url 'dashboard_admin' %}{% elif usuario.rol == 'medico' %}{% url 'dashboard_medico' %}{% else %}{% url 'dashboard_asistente' %}{% endif %}" 
+                            <a href="{% if usuario.rol == 'admin' %}{% url 'dashboard_admin' %}{% elif usuario.rol == 'medico' %}{% url 'dashboard_medico' %}{% else %}{% url 'citas_lista' %}{% endif %}"
                                class="btn btn-outline-secondary btn-lg px-4">
                                 <i class="bi bi-arrow-left me-2"></i>Volver al Dashboard
                             </a>


### PR DESCRIPTION
## Summary
- fix dashboard breadcrumb in profile templates
- add a role-aware "Volver al Dashboard" button in profile edit page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687df6868a88832483d580d6c848360c