### PR TITLE
Fix FullCalendar event display

### DIFF
--- a/consultorio_API/views.py
+++ b/consultorio_API/views.py
@@ -3862,8 +3862,7 @@ def citas_calendario_data(request):
             'title': f"{cita.paciente.nombre_completo}",
             'start': cita.fecha_hora.isoformat(),
             'end': (cita.fecha_hora + timedelta(minutes=cita.duracion)).isoformat(),
-            'backgroundColor': color,
-            'borderColor': color,
+            'color': color,
             'extendedProps': {
                 'numero_cita': cita.numero_cita,
                 'paciente': cita.paciente.nombre_completo,

--- a/consultorio_API/viewscitas.py
+++ b/consultorio_API/viewscitas.py
@@ -921,8 +921,7 @@ def citas_calendario_data(request):
                 'title': f"{cita.paciente.nombre_completo}",
                 'start': cita.fecha_hora.isoformat(),
                 'end': (cita.fecha_hora + timedelta(minutes=cita.duracion)).isoformat(),
-                'backgroundColor': color,
-                'borderColor': color,
+                'color': color,
                 'extendedProps': {
                     'numero_cita': cita.numero_cita,
                     'paciente': cita.paciente.nombre_completo,

--- a/templates/PAGES/citas/calendario.html
+++ b/templates/PAGES/citas/calendario.html
@@ -114,6 +114,8 @@ document.addEventListener('DOMContentLoaded', function() {
     var calendar = new FullCalendar.Calendar(calendarEl, {
         initialView: 'dayGridMonth',
         locale: 'es',
+        timeZone: 'local',
+        eventTimeFormat: { hour: '2-digit', minute: '2-digit', hour12: false },
         headerToolbar: {
             left: 'prev,next today',
             center: 'title',
@@ -141,9 +143,9 @@ document.addEventListener('DOMContentLoaded', function() {
                     // Aplicar clases CSS según si tiene médico o no
                     data.forEach(event => {
                         if (event.extendedProps.sin_medico) {
-                            event.className = 'fc-event-sin-medico';
+                            event.classNames = ['fc-event-sin-medico'];
                         } else {
-                            event.className = 'fc-event-con-medico';
+                            event.classNames = ['fc-event-con-medico'];
                         }
                     });
                     successCallback(data);


### PR DESCRIPTION
## Summary
- improve FullCalendar initialization
- return `color` property for events
- use `classNames` array for CSS classes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687df69bc14c83249f9728b07c05f777