### PR TITLE
Implementar auto-asignación y cancelación de consultas

### DIFF
--- a/consultorio_API/urls.py
+++ b/consultorio_API/urls.py
@@ -44,7 +44,7 @@ urlpatterns = [
     path('consultas/crear-sin-cita/', views.ConsultaSinCitaCreateView.as_view(), name='consultas_crear_sin_cita'),
     path('consultas/<int:pk>/precheck/', views.ConsultaPrecheckView.as_view(), name='consultas_precheck'),
     path('consultas/<int:pk>/atencion/', views.ConsultaAtencionView.as_view(), name='consultas_atencion'),
-    path('consultas/<int:pk>/cancelar/', views.ConsultaCancelarView.as_view(), name='consulta_cancelar'),
+    path('consultas/<int:pk>/cancelar/', views.cancelar_consulta, name='consulta_cancelar'),
     
     # HORARIOS
     path('horarios/', views.HorarioListView.as_view(), name='horarios_lista'),

--- a/templates/PAGES/consultas/consulta_card.html
+++ b/templates/PAGES/consultas/consulta_card.html
@@ -185,9 +185,13 @@
             {% if consulta.estado != "cancelada" and consulta.estado != "finalizada" %}
               <li><hr class="dropdown-divider"></li>
               <li>
-                <button class="dropdown-item text-danger" onclick="cancelarConsulta({{ consulta.pk }})">
-                  <i class="bi bi-x-circle me-2"></i>Cancelar
-                </button>
+                <form method="post" action="{% url 'consulta_cancelar' consulta.id %}" style="display:inline;">
+                  {% csrf_token %}
+                  <input type="hidden" name="next" value="{{ request.path }}">
+                  <button class="dropdown-item text-danger">
+                    <i class="bi bi-x-circle me-2"></i>Cancelar consulta
+                  </button>
+                </form>
               </li>
             {% endif %}
             
@@ -295,11 +299,6 @@ function verSignosVitales(consultaId) {
 }
 
 // Otras funciones existentes...
-function cancelarConsulta(consultaId) {
-    if (confirm('¿Está seguro de cancelar esta consulta?')) {
-        alert(`Consulta ID: ${consultaId} marcada como cancelada.\n\nFunción de cancelación en desarrollo.`);
-    }
-}
 
 function eliminarConsulta(consultaId) {
     if (confirm('¿Está seguro de eliminar esta consulta? Esta acción no se puede deshacer.')) {

--- a/templates/PAGES/consultas/detalle.html
+++ b/templates/PAGES/consultas/detalle.html
@@ -42,6 +42,11 @@
       <a href="{% url 'consulta_eliminar' consulta.pk %}?next={% url 'consultas_lista' %}" class="btn btn-danger me-1">
         <i class="bi bi-trash me-1"></i>Eliminar
       </a>
+      <form method="post" action="{% url 'consulta_cancelar' consulta.id %}" class="d-inline">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ request.path }}">
+        <button class="btn btn-danger me-1">Cancelar consulta</button>
+      </form>
       <a href="{% url 'consultas_lista' %}" class="btn btn-secondary">
         <i class="bi bi-arrow-left me-1"></i>Volver
       </a>

--- a/templates/PAGES/consultas/lista.html
+++ b/templates/PAGES/consultas/lista.html
@@ -562,11 +562,6 @@ function editarConsulta(consultaId) {
     alert(`Editar consulta ID: ${consultaId}\n\nFunción de edición en desarrollo.`);
 }
 
-function cancelarConsulta(consultaId) {
-    if (confirm('¿Está seguro de cancelar esta consulta?')) {
-        alert(`Consulta ID: ${consultaId} marcada como cancelada.\n\nFunción de cancelación en desarrollo.`);
-    }
-}
 
 function eliminarConsulta(consultaId) {
     if (confirm('¿Está seguro de eliminar esta consulta? Esta acción no se puede deshacer.')) {


### PR DESCRIPTION
## Summary
- auto-asignar médico en `ConsultaSinCitaForm`
- validar doctor disponible en `clean_medico`
- pasar `request` al formulario desde `ConsultaSinCitaCreateView`
- respetar parámetro `next` en la redirección
- crear vista `cancelar_consulta` solo POST y actualizar URL
- mostrar formulario de cancelación en tarjetas y detalle
- eliminar funciones JS de cancelación

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_687e1a8c7ed08324a10bfeca5355b5cd