### PR TITLE
Fix valid_until date formatting in RecetaForm

### DIFF
--- a/consultorio_API/forms.py
+++ b/consultorio_API/forms.py
@@ -971,7 +971,9 @@ class SignosVitalesForm(forms.ModelForm):
 
 class RecetaForm(forms.ModelForm):
     """Formulario para recetas médicas"""
-    
+
+    valido_hasta_input_formats = ["%Y-%m-%d", "%d/%m/%Y"]
+
     class Meta:
         model = Receta
         fields = ['indicaciones_generales', 'valido_hasta', 'notas']
@@ -981,10 +983,10 @@ class RecetaForm(forms.ModelForm):
                 'rows': 3,
                 'placeholder': 'Indicaciones generales para el paciente...'
             }),
-            'valido_hasta': forms.DateInput(attrs={
-                'type': 'date',
-                'class': 'form-control'
-            }),
+            'valido_hasta': forms.DateInput(
+                attrs={'type': 'date', 'class': 'form-control'},
+                format="%Y-%m-%d",
+            ),
             'notas': forms.Textarea(attrs={
                 'class': 'form-control',
                 'rows': 2,
@@ -999,12 +1001,15 @@ class RecetaForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Mostrar fecha guardada o valor por defecto
 
-        self.fields['valido_hasta'].initial = (
-            self.instance.valido_hasta
-            or timezone.now().date() + timedelta(days=30)
-        )
+        # Mostrar fecha guardada o valor por defecto
+        if self.instance and self.instance.pk and self.instance.valido_hasta:
+            self.initial["valido_hasta"] = self.instance.valido_hasta.strftime("%Y-%m-%d")
+        else:
+            self.fields['valido_hasta'].initial = (
+                self.instance.valido_hasta
+                or timezone.now().date() + timedelta(days=30)
+            )
 
 
 


### PR DESCRIPTION
## Summary
- show stored `valido_hasta` date when editing a recipe
- align `RecetaForm` date handling with `PacienteForm`

## Testing
- `python -m py_compile consultorio_API/forms.py`

------
https://chatgpt.com/codex/tasks/task_e_687e066db30883248f3e9088ba8c4dd7