### PR TITLE
Fix cancel buttons to respect next parameter

### DIFF
--- a/templates/PAGES/citas/crear.html
+++ b/templates/PAGES/citas/crear.html
@@ -121,6 +121,7 @@
                 <div class="card-body">
                     <form method="post" novalidate id="citaForm">
                         {% csrf_token %}
+                        <input type="hidden" name="next" value="{{ request.GET.next|default:'' }}">
 
                         <!-- Información del Paciente -->
                         <div class="form-section">
@@ -341,9 +342,15 @@
 
                         <!-- Botones -->
                         <div class="d-flex justify-content-end gap-2">
+                            {% if request.GET.next %}
+                            <a href="{{ request.GET.next }}" class="btn btn-secondary">
+                                <i class="fas fa-times me-2"></i>Cancelar
+                            </a>
+                            {% else %}
                             <a href="{% url 'citas_lista' %}" class="btn btn-secondary">
                                 <i class="fas fa-times me-2"></i>Cancelar
                             </a>
+                            {% endif %}
                             <button type="submit" class="btn btn-primary" id="submitBtn">
                                 <i class="fas fa-save me-2"></i>{{ accion }}
                             </button>

--- a/templates/PAGES/consultas/crear_sin_cita.html
+++ b/templates/PAGES/consultas/crear_sin_cita.html
@@ -63,6 +63,7 @@
 
                 <form method="post">
                     {% csrf_token %}
+                    <input type="hidden" name="next" value="{{ request.GET.next|default:'' }}">
                     
                     <div class="row">
                         <div class="col-md-6">
@@ -182,7 +183,6 @@
                         {{ form.observaciones_iniciales }}
                     </div>
 
-                    <input type="hidden" name="next" value="{{ next }}">
                     <!-- Asegurar que es sin cita -->
                     <input type="hidden" name="tipo" value="sin_cita">
 
@@ -198,9 +198,15 @@
                     </div>
 
                     <div class="d-flex justify-content-between">
-                        <a href="{{ next }}" class="btn btn-outline-secondary">
+                        {% if request.GET.next %}
+                        <a href="{{ request.GET.next }}" class="btn btn-outline-secondary">
                             <i class="bi bi-arrow-left me-1"></i>Cancelar
                         </a>
+                        {% else %}
+                        <a href="{% url 'consultas_lista' %}" class="btn btn-outline-secondary">
+                            <i class="bi bi-arrow-left me-1"></i>Cancelar
+                        </a>
+                        {% endif %}
                         <button type="submit" class="btn btn-success">
                             <i class="bi bi-check-circle me-1"></i>Crear Consulta
                         </button>


### PR DESCRIPTION
## Summary
- support optional `next` parameter in Crear Cita form
- support optional `next` parameter in Crear Consulta form

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_687e0905afcc8324903b4e5a27397826