### PR TITLE
Fix next parameter propagation on dashboard quick actions

### DIFF
--- a/templates/PAGES/dashboard.html
+++ b/templates/PAGES/dashboard.html
@@ -250,8 +250,9 @@
         <div class="card-body">
           <div class="row g-3">
             {% if usuario.rol == "admin" or usuario.rol == "medico" or usuario.rol == "asistente" %}
+            {% url 'citas_crear' as crear_cita %}
             <div class="col-md-2 col-6">
-              <a href="{% url 'citas_crear' %}" class="btn btn-outline-primary quick-action-btn w-100">
+              <a href="{{ crear_cita }}?next={{ request.path }}" class="btn btn-outline-primary quick-action-btn w-100">
                 <i class="bi bi-calendar-plus fs-3 mb-1"></i>
                 <small>Nueva Cita</small>
               </a>
@@ -259,8 +260,9 @@
             {% endif %}
             
             {% if usuario.rol == "admin" or usuario.rol == "medico" %}
+            {% url 'consultas_crear_sin_cita' as crear_consulta %}
             <div class="col-md-2 col-6">
-              <a href="{% url 'consultas_crear_sin_cita' %}" class="btn btn-outline-success quick-action-btn w-100">
+              <a href="{{ crear_consulta }}?next={{ request.path }}" class="btn btn-outline-success quick-action-btn w-100">
                 <i class="bi bi-clipboard-plus fs-3 mb-1"></i>
                 <small>Nueva Consulta</small>
               </a>


### PR DESCRIPTION
## Summary
- propagate next parameter in Nueva Cita and Nueva Consulta links
- run `python manage.py check`

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_687e0a3fe2648324a36939fea8edd040