### PR TITLE
Enforce single consultation in progress

### DIFF
--- a/templates/PAGES/consultas/consulta_card.html
+++ b/templates/PAGES/consultas/consulta_card.html
@@ -109,11 +109,17 @@
         </div>
         {% else %}
         <div class="btn-group" role="group">
-          {% if consulta.estado != "finalizada" and consulta.estado != "cancelada" %}
-            <a href="{% url 'consultas_atencion' consulta.pk %}"
-               class="btn btn-primary btn-sm">
-              <i class="bi bi-clipboard-plus me-1"></i>Atender
-            </a>
+          {% if consulta.estado == "espera" %}
+            {% if not tiene_en_progreso %}
+              <a href="{% url 'consultas_atencion' consulta.pk %}"
+                 class="btn btn-primary btn-sm">
+                <i class="bi bi-clipboard-plus me-1"></i>Atender
+              </a>
+            {% else %}
+              <button class="btn btn-primary btn-sm" disabled>
+                <i class="bi bi-clipboard-plus me-1"></i>Atender
+              </button>
+            {% endif %}
           {% endif %}
 
           {% if consulta.signos_vitales %}

--- a/templates/PAGES/consultas/detalle.html
+++ b/templates/PAGES/consultas/detalle.html
@@ -26,9 +26,15 @@
     </div>
     <div class="col-md-4 text-md-end">
       {% if consulta.estado == 'espera' and puede_editar %}
-        <a href="{% url 'consultas_atencion' consulta.pk %}" class="btn btn-primary me-1">
-          <i class="bi bi-play me-1"></i>Atender
-        </a>
+        {% if not tiene_en_progreso %}
+          <a href="{% url 'consultas_atencion' consulta.pk %}" class="btn btn-primary me-1">
+            <i class="bi bi-play me-1"></i>Atender
+          </a>
+        {% else %}
+          <button class="btn btn-primary me-1" disabled>
+            <i class="bi bi-play me-1"></i>Atender
+          </button>
+        {% endif %}
       {% elif puede_editar %}
         <a href="{% url 'consulta_editar' consulta.pk %}" class="btn btn-warning me-1">
           <i class="bi bi-pencil me-1"></i>Editar


### PR DESCRIPTION
## Summary
- track if a doctor has a consultation already in progress
- block "Atender" when another consultation is active
- disable Attend buttons when already busy

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687e1f812cc88324afff7f58c9cf4d5a