### PR TITLE
Enforce single active consultation

### DIFF
--- a/consultorio_API/urls.py
+++ b/consultorio_API/urls.py
@@ -44,7 +44,7 @@ urlpatterns = [
     path('consultas/crear-sin-cita/', views.ConsultaSinCitaCreateView.as_view(), name='consultas_crear_sin_cita'),
     path('consultas/<int:pk>/precheck/', views.ConsultaPrecheckView.as_view(), name='consultas_precheck'),
     path('consultas/<int:pk>/atencion/', views.ConsultaAtencionView.as_view(), name='consultas_atencion'),
-    path('consultas/<int:pk>/cancelar/', views.ConsultaCancelarView.as_view(), name='consulta_cancelar'),
+    path('consultas/<int:pk>/cancelar/', views.cancelar_consulta, name='cancelar_consulta'),
     
     # HORARIOS
     path('horarios/', views.HorarioListView.as_view(), name='horarios_lista'),

--- a/templates/PAGES/consultas/consulta_card.html
+++ b/templates/PAGES/consultas/consulta_card.html
@@ -109,11 +109,13 @@
         </div>
         {% else %}
         <div class="btn-group" role="group">
-          {% if consulta.estado != "finalizada" and consulta.estado != "cancelada" %}
-            <a href="{% url 'consultas_atencion' consulta.pk %}"
-               class="btn btn-primary btn-sm">
-              <i class="bi bi-clipboard-plus me-1"></i>Atender
-            </a>
+          {% if consulta.estado == "espera" and usuario.rol == "medico" %}
+            {% if not consulta_activa or consulta_activa.pk == consulta.pk %}
+              <a href="{% url 'consultas_atencion' consulta.pk %}?next={{ request.get_full_path }}"
+                 class="btn btn-primary btn-sm">
+                <i class="bi bi-clipboard-plus me-1"></i>Atender
+              </a>
+            {% endif %}
           {% endif %}
 
           {% if consulta.signos_vitales %}
@@ -185,10 +187,26 @@
             {% if consulta.estado != "cancelada" and consulta.estado != "finalizada" %}
               <li><hr class="dropdown-divider"></li>
               <li>
-                <button class="dropdown-item text-danger" onclick="cancelarConsulta({{ consulta.pk }})">
-                  <i class="bi bi-x-circle me-2"></i>Cancelar
-                </button>
+                <form method="post" action="{% url 'cancelar_consulta' consulta.pk %}">
+                  {% csrf_token %}
+                  <input type="hidden" name="next" value="{{ request.path }}">
+                  <button type="submit" class="dropdown-item text-danger">
+                    <i class="bi bi-x-circle me-2"></i>Cancelar
+                  </button>
+                </form>
               </li>
+              {% if consulta.estado == "en_progreso" and consulta.medico == usuario %}
+              <li>
+                <form method="post" action="{% url 'consultas_atencion' consulta.pk %}">
+                  {% csrf_token %}
+                  <input type="hidden" name="action" value="finish">
+                  <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                  <button type="submit" class="dropdown-item text-success">
+                    <i class="bi bi-check-circle me-2"></i>Finalizar
+                  </button>
+                </form>
+              </li>
+              {% endif %}
             {% endif %}
             
             {% if consulta.estado == "cancelada" or consulta.estado == "finalizada" %}

--- a/templates/PAGES/consultas/detalle.html
+++ b/templates/PAGES/consultas/detalle.html
@@ -25,8 +25,8 @@
       <p class="text-muted mb-0">{{ consulta.paciente.nombre_completo }}</p>
     </div>
     <div class="col-md-4 text-md-end">
-      {% if consulta.estado == 'espera' and puede_editar %}
-        <a href="{% url 'consultas_atencion' consulta.pk %}" class="btn btn-primary me-1">
+      {% if consulta.estado == 'espera' and puede_editar and (not consulta_activa or consulta_activa.pk == consulta.pk) %}
+        <a href="{% url 'consultas_atencion' consulta.pk %}?next={{ request.get_full_path }}" class="btn btn-primary me-1">
           <i class="bi bi-play me-1"></i>Atender
         </a>
       {% elif puede_editar %}
@@ -254,8 +254,8 @@
         </div>
         <div class="card-body">
           <div class="d-grid gap-2">
-            {% if consulta.estado == 'espera' %}
-              <a href="{% url 'consultas_atencion' consulta.pk %}" class="btn btn-primary btn-sm">
+            {% if consulta.estado == 'espera' and (not consulta_activa or consulta_activa.pk == consulta.pk) %}
+              <a href="{% url 'consultas_atencion' consulta.pk %}?next={{ request.get_full_path }}" class="btn btn-primary btn-sm">
                 <i class="bi bi-play me-1"></i>Iniciar Atención
               </a>
             {% endif %}
@@ -270,6 +270,27 @@
               <a href="{% url 'consulta_editar' consulta.pk %}" class="btn btn-outline-secondary btn-sm">
                 <i class="bi bi-pencil me-1"></i>Editar Consulta
               </a>
+            {% endif %}
+
+            {% if consulta.estado in 'espera en_progreso'.split %}
+              <form method="post" action="{% url 'cancelar_consulta' consulta.pk %}">
+                {% csrf_token %}
+                <input type="hidden" name="next" value="{{ request.path }}">
+                <button type="submit" class="btn btn-outline-danger btn-sm">
+                  <i class="bi bi-x-circle me-1"></i>Cancelar Consulta
+                </button>
+              </form>
+            {% endif %}
+
+            {% if consulta.estado == 'en_progreso' and consulta.medico == usuario %}
+              <form method="post" action="{% url 'consultas_atencion' consulta.pk %}">
+                {% csrf_token %}
+                <input type="hidden" name="action" value="finish">
+                <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                <button type="submit" class="btn btn-success btn-sm">
+                  <i class="bi bi-check-circle me-1"></i>Finalizar Consulta
+                </button>
+              </form>
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- auto-select current doctor or assistant in new consultation form
- only list doctors without an active consultation for admins
- redirect create view respecting ?next parameter
- restrict the POST cancel view and update the appointment
- wire cancel forms to use `next` value consistently

## Testing
- `python manage.py check`
- `pytest -q`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_687df6942b84832486df7331818fa7d7