### PR TITLE
Implement cancel/delete for consultas

### DIFF
--- a/consultorio_API/urls.py
+++ b/consultorio_API/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from .views import *
 from django.contrib.auth.views import LogoutView
 from .views import CitaCreateView, Receta
-from consultorio_API import views, viewscitas 
+from consultorio_API import views, viewscitas, views_consultas
 
 urlpatterns = [
       # LOGIN Y LOGOUT
@@ -40,11 +40,11 @@ urlpatterns = [
     path('consultas/', views.ConsultaListView.as_view(), name='consultas_lista'),
     path('consultas/<int:pk>/', views.ConsultaDetailView.as_view(), name='consulta_detalle'),
     path('consultas/<int:pk>/editar/', views.ConsultaUpdateView.as_view(), name='consulta_editar'),
-    path('consultas/<int:pk>/eliminar/', views.ConsultaDeleteView.as_view(), name='consulta_eliminar'),
+    path('consultas/<int:pk>/eliminar/', views_consultas.eliminar_consulta, name='consulta_eliminar'),
     path('consultas/crear-sin-cita/', views.ConsultaSinCitaCreateView.as_view(), name='consultas_crear_sin_cita'),
     path('consultas/<int:pk>/precheck/', views.ConsultaPrecheckView.as_view(), name='consultas_precheck'),
     path('consultas/<int:pk>/atencion/', views.ConsultaAtencionView.as_view(), name='consultas_atencion'),
-    path('consultas/<int:pk>/cancelar/', views.ConsultaCancelarView.as_view(), name='consulta_cancelar'),
+    path('consultas/<int:pk>/cancelar/', views_consultas.cancelar_consulta, name='consulta_cancelar'),
     
     # HORARIOS
     path('horarios/', views.HorarioListView.as_view(), name='horarios_lista'),

--- a/consultorio_API/views_consultas.py
+++ b/consultorio_API/views_consultas.py
@@ -1,0 +1,54 @@
+from django.shortcuts import get_object_or_404, redirect
+from django.contrib.auth.decorators import login_required
+from django.contrib import messages
+from django.urls import reverse
+from django.views.decorators.http import require_POST
+
+from .models import Consulta
+
+
+@require_POST
+@login_required
+def eliminar_consulta(request, pk):
+    """Eliminar una consulta y su cita asociada si existe."""
+    consulta = get_object_or_404(Consulta, pk=pk)
+
+    if not (request.user == consulta.medico or request.user.rol == "admin"):
+        messages.error(request, "Acción no autorizada.")
+        return redirect(request.POST.get("next") or reverse("consultas_lista"))
+
+    if consulta.estado == "en_progreso":
+        messages.error(request, "Acción no autorizada.")
+        return redirect(request.POST.get("next") or reverse("consultas_lista"))
+
+    if consulta.cita:
+        consulta.cita.delete()
+    consulta.delete()
+
+    messages.success(request, "Consulta eliminada correctamente.")
+    return redirect(request.POST.get("next") or reverse("consultas_lista"))
+
+
+@require_POST
+@login_required
+def cancelar_consulta(request, pk):
+    """Cancelar una consulta y su cita asociada si existe."""
+    consulta = get_object_or_404(Consulta, pk=pk)
+
+    if not (request.user == consulta.medico or request.user.rol == "admin"):
+        messages.error(request, "Acción no autorizada.")
+        return redirect(request.POST.get("next") or reverse("consultas_lista"))
+
+    if consulta.estado not in ["espera", "en_progreso"]:
+        messages.error(request, "Acción no autorizada.")
+        return redirect(request.POST.get("next") or reverse("consultas_lista"))
+
+    consulta.estado = "cancelada"
+    consulta.save()
+
+    if consulta.cita:
+        consulta.cita.estado = "cancelada"
+        consulta.cita.save()
+
+    messages.success(request, "Consulta cancelada.")
+    return redirect(request.POST.get("next") or reverse("consultas_lista"))

--- a/templates/PAGES/consultas/consulta_card.html
+++ b/templates/PAGES/consultas/consulta_card.html
@@ -182,21 +182,29 @@
               {% endif %}
             {% endif %}
             
-            {% if consulta.estado != "cancelada" and consulta.estado != "finalizada" %}
+            {% if consulta.estado in ["espera", "en_progreso"] %}
               <li><hr class="dropdown-divider"></li>
               <li>
-                <button class="dropdown-item text-danger" onclick="cancelarConsulta({{ consulta.pk }})">
-                  <i class="bi bi-x-circle me-2"></i>Cancelar
-                </button>
+                <form method="post" action="{% url 'consulta_cancelar' consulta.pk %}">
+                  {% csrf_token %}
+                  <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                  <button type="submit" class="dropdown-item text-warning">
+                    <i class="bi bi-x-circle me-2"></i>Cancelar
+                  </button>
+                </form>
               </li>
             {% endif %}
-            
-            {% if consulta.estado == "cancelada" or consulta.estado == "finalizada" %}
+
+            {% if consulta.estado != "en_progreso" %}
               <li><hr class="dropdown-divider"></li>
               <li>
-                <button class="dropdown-item text-danger" onclick="eliminarConsulta({{ consulta.pk }})">
-                  <i class="bi bi-trash me-2"></i>Eliminar
-                </button>
+                <form method="post" action="{% url 'consulta_eliminar' consulta.pk %}">
+                  {% csrf_token %}
+                  <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                  <button type="submit" class="dropdown-item text-danger">
+                    <i class="bi bi-trash me-2"></i>Eliminar
+                  </button>
+                </form>
               </li>
             {% endif %}
           </ul>
@@ -295,15 +303,5 @@ function verSignosVitales(consultaId) {
 }
 
 // Otras funciones existentes...
-function cancelarConsulta(consultaId) {
-    if (confirm('¿Está seguro de cancelar esta consulta?')) {
-        alert(`Consulta ID: ${consultaId} marcada como cancelada.\n\nFunción de cancelación en desarrollo.`);
-    }
-}
-
-function eliminarConsulta(consultaId) {
-    if (confirm('¿Está seguro de eliminar esta consulta? Esta acción no se puede deshacer.')) {
-        alert(`Consulta ID: ${consultaId} eliminada.\n\nFunción de eliminación en desarrollo.`);
-    }
-}
+// Las acciones de cancelar y eliminar se realizan mediante formularios POST
 </script>

--- a/templates/PAGES/consultas/detalle.html
+++ b/templates/PAGES/consultas/detalle.html
@@ -39,9 +39,24 @@
           <i class="bi bi-printer me-1"></i>Imprimir
         </a>
       {% endif %}
-      <a href="{% url 'consulta_eliminar' consulta.pk %}?next={% url 'consultas_lista' %}" class="btn btn-danger me-1">
-        <i class="bi bi-trash me-1"></i>Eliminar
-      </a>
+      {% if consulta.estado in ['espera', 'en_progreso'] %}
+      <form method="post" action="{% url 'consulta_cancelar' consulta.pk %}" class="d-inline">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ request.get_full_path }}">
+        <button type="submit" class="btn btn-warning me-1">
+          <i class="bi bi-x-circle me-1"></i>Cancelar
+        </button>
+      </form>
+      {% endif %}
+      {% if consulta.estado != 'en_progreso' %}
+      <form method="post" action="{% url 'consulta_eliminar' consulta.pk %}" class="d-inline">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ request.get_full_path }}">
+        <button type="submit" class="btn btn-danger me-1">
+          <i class="bi bi-trash me-1"></i>Eliminar
+        </button>
+      </form>
+      {% endif %}
       <a href="{% url 'consultas_lista' %}" class="btn btn-secondary">
         <i class="bi bi-arrow-left me-1"></i>Volver
       </a>

--- a/templates/PAGES/consultas/lista.html
+++ b/templates/PAGES/consultas/lista.html
@@ -562,17 +562,7 @@ function editarConsulta(consultaId) {
     alert(`Editar consulta ID: ${consultaId}\n\nFunción de edición en desarrollo.`);
 }
 
-function cancelarConsulta(consultaId) {
-    if (confirm('¿Está seguro de cancelar esta consulta?')) {
-        alert(`Consulta ID: ${consultaId} marcada como cancelada.\n\nFunción de cancelación en desarrollo.`);
-    }
-}
 
-function eliminarConsulta(consultaId) {
-    if (confirm('¿Está seguro de eliminar esta consulta? Esta acción no se puede deshacer.')) {
-        alert(`Consulta ID: ${consultaId} eliminada.\n\nFunción de eliminación en desarrollo.`);
-    }
-}
 
 function verSignosVitales(consultaId) {
     window.location.href = `/signos/${consultaId}`;


### PR DESCRIPTION
## Summary
- add `eliminar_consulta` and `cancelar_consulta` views
- wire new views in URL routes
- show cancel and delete buttons on consulta list cards
- update consulta detail actions
- remove obsolete JS handlers

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687f52b5f6f08324a60e053752770b43