### PR TITLE
Improve consultation workflow

### DIFF
--- a/templates/PAGES/consultas/consulta_card.html
+++ b/templates/PAGES/consultas/consulta_card.html
@@ -109,11 +109,27 @@
         </div>
         {% else %}
         <div class="btn-group" role="group">
-          {% if consulta.estado != "finalizada" and consulta.estado != "cancelada" %}
-            <a href="{% url 'consultas_atencion' consulta.pk %}"
-               class="btn btn-primary btn-sm">
-              <i class="bi bi-clipboard-plus me-1"></i>Atender
-            </a>
+          {% if consulta.estado == "espera" %}
+            {% if not consulta_en_progreso_pk or consulta_en_progreso_pk == consulta.pk %}
+              <form method="post" action="{% url 'consultas_atencion' consulta.pk %}">
+                {% csrf_token %}
+                <input type="hidden" name="action" value="start">
+                <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                <button type="submit" class="btn btn-primary btn-sm">
+                  <i class="bi bi-clipboard-plus me-1"></i>Atender
+                </button>
+              </form>
+            {% endif %}
+          {% endif %}
+          {% if usuario == consulta.medico and consulta.estado == "en_progreso" %}
+            <form method="post" action="{% url 'consultas_atencion' consulta.pk %}" class="ms-1">
+              {% csrf_token %}
+              <input type="hidden" name="action" value="finish">
+              <input type="hidden" name="next" value="{{ request.get_full_path }}">
+              <button type="submit" class="btn btn-success btn-sm">
+                <i class="bi bi-check-circle me-1"></i>Finalizar
+              </button>
+            </form>
           {% endif %}
 
           {% if consulta.signos_vitales %}
@@ -182,12 +198,16 @@
               {% endif %}
             {% endif %}
             
-            {% if consulta.estado != "cancelada" and consulta.estado != "finalizada" %}
+            {% if consulta.estado in ["espera", "en_progreso"] %}
               <li><hr class="dropdown-divider"></li>
               <li>
-                <button class="dropdown-item text-danger" onclick="cancelarConsulta({{ consulta.pk }})">
-                  <i class="bi bi-x-circle me-2"></i>Cancelar
-                </button>
+                <form method="post" action="{% url 'consulta_cancelar' consulta.pk %}">
+                  {% csrf_token %}
+                  <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                  <button type="submit" class="dropdown-item text-danger">
+                    <i class="bi bi-x-circle me-2"></i>Cancelar
+                  </button>
+                </form>
               </li>
             {% endif %}
             

--- a/templates/PAGES/consultas/detalle.html
+++ b/templates/PAGES/consultas/detalle.html
@@ -26,9 +26,25 @@
     </div>
     <div class="col-md-4 text-md-end">
       {% if consulta.estado == 'espera' and puede_editar %}
-        <a href="{% url 'consultas_atencion' consulta.pk %}" class="btn btn-primary me-1">
-          <i class="bi bi-play me-1"></i>Atender
-        </a>
+        {% if not consulta_en_progreso_pk or consulta_en_progreso_pk == consulta.pk %}
+          <form method="post" action="{% url 'consultas_atencion' consulta.pk %}" class="d-inline">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="start">
+            <input type="hidden" name="next" value="{{ request.get_full_path }}">
+            <button type="submit" class="btn btn-primary me-1">
+              <i class="bi bi-play me-1"></i>Atender
+            </button>
+          </form>
+        {% endif %}
+      {% elif consulta.estado == 'en_progreso' and usuario == consulta.medico %}
+        <form method="post" action="{% url 'consultas_atencion' consulta.pk %}" class="d-inline">
+          {% csrf_token %}
+          <input type="hidden" name="action" value="finish">
+          <input type="hidden" name="next" value="{{ request.get_full_path }}">
+          <button type="submit" class="btn btn-success me-1">
+            <i class="bi bi-check-circle me-1"></i>Finalizar
+          </button>
+        </form>
       {% elif puede_editar %}
         <a href="{% url 'consulta_editar' consulta.pk %}" class="btn btn-warning me-1">
           <i class="bi bi-pencil me-1"></i>Editar
@@ -255,17 +271,45 @@
         <div class="card-body">
           <div class="d-grid gap-2">
             {% if consulta.estado == 'espera' %}
-              <a href="{% url 'consultas_atencion' consulta.pk %}" class="btn btn-primary btn-sm">
-                <i class="bi bi-play me-1"></i>Iniciar Atención
-              </a>
+              {% if not consulta_en_progreso_pk or consulta_en_progreso_pk == consulta.pk %}
+                <form method="post" action="{% url 'consultas_atencion' consulta.pk %}">
+                  {% csrf_token %}
+                  <input type="hidden" name="action" value="start">
+                  <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                  <button type="submit" class="btn btn-primary btn-sm">
+                    <i class="bi bi-play me-1"></i>Iniciar Atención
+                  </button>
+                </form>
+              {% endif %}
             {% endif %}
-            
+
             {% if not signos_vitales %}
               <a href="{% url 'consultas_precheck' consulta.pk %}" class="btn btn-warning btn-sm">
                 <i class="bi bi-heart-pulse me-1"></i>Registrar Signos
               </a>
             {% endif %}
             
+            {% if consulta.estado in ['espera', 'en_progreso'] %}
+              <form method="post" action="{% url 'consulta_cancelar' consulta.pk %}">
+                {% csrf_token %}
+                <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                <button type="submit" class="btn btn-danger btn-sm">
+                  <i class="bi bi-x-circle me-1"></i>Cancelar
+                </button>
+              </form>
+            {% endif %}
+
+            {% if consulta.estado == 'en_progreso' and usuario == consulta.medico %}
+              <form method="post" action="{% url 'consultas_atencion' consulta.pk %}">
+                {% csrf_token %}
+                <input type="hidden" name="action" value="finish">
+                <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                <button type="submit" class="btn btn-success btn-sm">
+                  <i class="bi bi-check-circle me-1"></i>Finalizar
+                </button>
+              </form>
+            {% endif %}
+
             {% if puede_editar %}
               <a href="{% url 'consulta_editar' consulta.pk %}" class="btn btn-outline-secondary btn-sm">
                 <i class="bi bi-pencil me-1"></i>Editar Consulta


### PR DESCRIPTION
## Summary
- auto-assign doctor and hide field on instant consultation form
- prevent multiple consultations in progress for the same doctor
- pass current user to form in `ConsultaSinCitaCreateView`
- update success message when creating an instant consultation
- restrict attending consultations when doctor already busy
- add start/finish/cancel forms with next propagation in templates
- fix template logic when checking for an active consultation

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_687f4f553af883249618ac148846c0ce