### PR TITLE
Implement cancel and delete for Consulta

### DIFF
--- a/consultorio_API/signals.py
+++ b/consultorio_API/signals.py
@@ -202,6 +202,21 @@ def auditar_cambios_consulta(sender, instance, **kwargs):
     except Consulta.DoesNotExist:
         pass
 
+
+@receiver(post_delete, sender=Consulta)
+def auditar_consulta_delete(sender, instance, **kwargs):
+    """Registrar eliminación de consultas."""
+    usuario_actual = get_current_user()
+    request = get_current_request()
+    if usuario_actual:
+        registrar(
+            usuario_actual,
+            "eliminar_consulta",
+            instance,
+            f"Consulta de {instance.paciente.nombre_completo} eliminada",
+            request,
+        )
+
 # ═══════════════════════════════════════════════════════════════
 # 📊 SEÑALES DE SIGNOS VITALES
 # ═══════════════════════════════════════════════════════════════

--- a/consultorio_API/urls.py
+++ b/consultorio_API/urls.py
@@ -7,6 +7,7 @@ from .views_consultorios import (
     ConsultorioUpdateView,
     ConsultorioDeleteView,
 )
+from .views_consultas import cancelar_consulta, eliminar_consulta
 from django.contrib.auth.views import LogoutView
 from .views import CitaCreateView, Receta
 from consultorio_API import views, viewscitas 
@@ -54,11 +55,11 @@ urlpatterns = [
     path('consultas/', views.ConsultaListView.as_view(), name='consultas_lista'),
     path('consultas/<int:pk>/', views.ConsultaDetailView.as_view(), name='consulta_detalle'),
     path('consultas/<int:pk>/editar/', views.ConsultaUpdateView.as_view(), name='consulta_editar'),
-    path('consultas/<int:pk>/eliminar/', views.ConsultaDeleteView.as_view(), name='consulta_eliminar'),
+    path('consultas/<int:pk>/eliminar/', eliminar_consulta, name='consulta_eliminar'),
     path('consultas/crear-sin-cita/', views.ConsultaSinCitaCreateView.as_view(), name='consultas_crear_sin_cita'),
     path('consultas/<int:pk>/precheck/', views.ConsultaPrecheckView.as_view(), name='consultas_precheck'),
     path('consultas/<int:pk>/atencion/', views.ConsultaAtencionView.as_view(), name='consultas_atencion'),
-    path('consultas/<int:pk>/cancelar/', views.ConsultaCancelarView.as_view(), name='consulta_cancelar'),
+    path('consultas/<int:pk>/cancelar/', cancelar_consulta, name='consulta_cancelar'),
     
     # HORARIOS
     path('horarios/', views.HorarioListView.as_view(), name='horarios_lista'),

--- a/consultorio_API/views_consultas.py
+++ b/consultorio_API/views_consultas.py
@@ -1,0 +1,46 @@
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404, redirect
+from django.views.decorators.http import require_POST
+
+from .models import Consulta
+
+
+def puede_modificar(user, consulta):
+    """Return True if user is admin or the assigned medico."""
+    return user.rol == 'admin' or consulta.medico == user
+
+
+@login_required
+@require_POST
+def cancelar_consulta(request, pk):
+    consulta = get_object_or_404(Consulta, pk=pk)
+    if not puede_modificar(request.user, consulta):
+        messages.error(request, "Acción no autorizada.")
+        return redirect("consultas_lista")
+
+    consulta.estado = "cancelada"
+    consulta.save(update_fields=["estado"])
+
+    if consulta.cita:
+        consulta.cita.estado = "cancelada"
+        consulta.cita.save(update_fields=["estado"])
+
+    messages.success(request, "Consulta cancelada.")
+    return redirect(request.POST.get("next") or "consultas_lista")
+
+
+@login_required
+@require_POST
+def eliminar_consulta(request, pk):
+    consulta = get_object_or_404(Consulta, pk=pk)
+    if not puede_modificar(request.user, consulta):
+        messages.error(request, "Acción no autorizada.")
+        return redirect("consultas_lista")
+
+    if consulta.cita:
+        consulta.cita.delete()
+    consulta.delete()
+
+    messages.success(request, "Consulta eliminada.")
+    return redirect(request.POST.get("next") or "consultas_lista")

--- a/templates/PAGES/consultas/consulta_card.html
+++ b/templates/PAGES/consultas/consulta_card.html
@@ -182,21 +182,27 @@
               {% endif %}
             {% endif %}
             
-            {% if consulta.estado != "cancelada" and consulta.estado != "finalizada" %}
-              <li><hr class="dropdown-divider"></li>
+            {% if consulta.estado == "espera" or consulta.estado == "en_progreso" %}
               <li>
-                <button class="dropdown-item text-danger" onclick="cancelarConsulta({{ consulta.pk }})">
-                  <i class="bi bi-x-circle me-2"></i>Cancelar
-                </button>
+                <form method="post" action="{% url 'consulta_cancelar' consulta.pk %}">
+                  {% csrf_token %}
+                  <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                  <button class="dropdown-item text-warning">
+                    <i class="bi bi-x-circle me-2"></i>Cancelar
+                  </button>
+                </form>
               </li>
             {% endif %}
-            
-            {% if consulta.estado == "cancelada" or consulta.estado == "finalizada" %}
-              <li><hr class="dropdown-divider"></li>
+
+            {% if consulta.estado != "en_progreso" %}
               <li>
-                <button class="dropdown-item text-danger" onclick="eliminarConsulta({{ consulta.pk }})">
-                  <i class="bi bi-trash me-2"></i>Eliminar
-                </button>
+                <form method="post" action="{% url 'consulta_eliminar' consulta.pk %}">
+                  {% csrf_token %}
+                  <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                  <button class="dropdown-item text-danger">
+                    <i class="bi bi-trash me-2"></i>Eliminar
+                  </button>
+                </form>
               </li>
             {% endif %}
           </ul>

--- a/templates/PAGES/consultas/detalle.html
+++ b/templates/PAGES/consultas/detalle.html
@@ -39,9 +39,25 @@
           <i class="bi bi-printer me-1"></i>Imprimir
         </a>
       {% endif %}
-      <a href="{% url 'consulta_eliminar' consulta.pk %}?next={% url 'consultas_lista' %}" class="btn btn-danger me-1">
-        <i class="bi bi-trash me-1"></i>Eliminar
-      </a>
+      {% if consulta.estado == 'espera' or consulta.estado == 'en_progreso' %}
+      <form method="post" action="{% url 'consulta_cancelar' consulta.pk %}" class="d-inline">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ request.get_full_path }}">
+        <button class="btn btn-warning me-1" type="submit">
+          <i class="bi bi-x-circle me-1"></i>Cancelar
+        </button>
+      </form>
+      {% endif %}
+
+      {% if consulta.estado != 'en_progreso' %}
+      <form method="post" action="{% url 'consulta_eliminar' consulta.pk %}" class="d-inline">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ request.get_full_path }}">
+        <button class="btn btn-danger me-1" type="submit">
+          <i class="bi bi-trash me-1"></i>Eliminar
+        </button>
+      </form>
+      {% endif %}
       <a href="{% url 'consultas_lista' %}" class="btn btn-secondary">
         <i class="bi bi-arrow-left me-1"></i>Volver
       </a>


### PR DESCRIPTION
## Summary
- add new views `cancelar_consulta` and `eliminar_consulta`
- integrate URLs with new function views
- log deletion of consultas in signals
- update consultation card and detail templates with cancel/delete forms

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687f578249f48324becb264c8ae57e8c