### PR TITLE
Fix consultorio create redirects

### DIFF
--- a/consultorio_API/views_consultorios.py
+++ b/consultorio_API/views_consultorios.py
@@ -53,8 +53,12 @@ class ConsultorioCreateView(NextRedirectMixin, AdminRequiredMixin, CreateView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx["usuario"] = self.request.user
-        ctx["next"] = self.get_next_url()
+        ctx["next"] = self.request.GET.get("next") or self.request.POST.get("next")
         return ctx
+
+    def get_success_url(self):
+        next_url = self.request.GET.get("next") or self.request.POST.get("next")
+        return next_url or reverse_lazy("consultorios_lista")
 
 
 @method_decorator(login_required, name="dispatch")

--- a/templates/PAGES/consultorios/form.html
+++ b/templates/PAGES/consultorios/form.html
@@ -25,7 +25,9 @@
             {% endfor %}
           </div>
         {% endfor %}
-        <input type="hidden" name="next" value="{{ next }}">
+        {% if request.GET.next %}
+        <input type="hidden" name="next" value="{{ request.GET.next }}">
+        {% endif %}
         <div class="d-flex justify-content-end">
           <a href="{{ next|default:request.META.HTTP_REFERER|default:'#' }}" class="btn btn-secondary me-2">Cancelar</a>
           <button type="submit" class="btn btn-primary">Guardar</button>

--- a/templates/PAGES/consultorios/lista.html
+++ b/templates/PAGES/consultorios/lista.html
@@ -11,7 +11,7 @@
 
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h3 class="text-primary fw-bold mb-0">Consultorios</h3>
-    <a href="{% url 'consultorio_crear' %}" class="btn btn-primary">
+    <a href="{% url 'consultorio_crear' %}{% if request.get_full_path %}?next={{ request.get_full_path|urlencode }}{% endif %}" class="btn btn-primary">
       <i class="bi bi-plus-lg me-1"></i> Nuevo Consultorio
     </a>
   </div>


### PR DESCRIPTION
## Summary
- keep `next` param when creating consultorios and avoid `None` urls
- only render the hidden `next` field when `next` comes from GET

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f5b4af6cc8324a49515bf34230238