### PR TITLE
Fix consultas medico selection and exclusivity

### DIFF
--- a/consultorio_API/tests/conftest.py
+++ b/consultorio_API/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from django.conf import settings
+
+def pytest_configure():
+    settings.DATABASES['default'] = {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+        'ATOMIC_REQUESTS': False,
+    }

--- a/consultorio_API/tests/test_consulta.py
+++ b/consultorio_API/tests/test_consulta.py
@@ -1,0 +1,44 @@
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from consultorio_API.models import Usuario, Paciente, Consulta, Consultorio, Cita
+from consultorio_API.views import doctor_tiene_consulta_en_progreso
+
+@pytest.mark.django_db
+def test_doctor_solo_una_en_progreso(client):
+    consultorio = Consultorio.objects.create(nombre="C1")
+    medico = Usuario.objects.create(username="doc", rol="medico", first_name="Doc", consultorio=consultorio)
+    paciente1 = Paciente.objects.create(nombre_completo="P1", fecha_nacimiento="2000-01-01", sexo='M', telefono='1', correo='a@a.com', direccion='x', consultorio_asignado=medico)
+    paciente2 = Paciente.objects.create(nombre_completo="P2", fecha_nacimiento="2000-01-01", sexo='M', telefono='1', correo='b@b.com', direccion='x', consultorio_asignado=medico)
+    c1 = Consulta.objects.create(paciente=paciente1, medico=medico, tipo='sin_cita', estado='en_progreso')
+    c2 = Consulta.objects.create(paciente=paciente2, medico=medico, tipo='sin_cita', estado='espera')
+
+    assert doctor_tiene_consulta_en_progreso(medico) is True
+
+    client.force_login(medico)
+    url = reverse('consultas_atencion', args=[c2.pk])
+    client.get(url)
+    c2.refresh_from_db()
+    assert c2.estado == 'espera'
+
+@pytest.mark.django_db
+def test_form_consulta_solapa(db, client):
+    consultorio = Consultorio.objects.create(nombre="C2")
+    medico = Usuario.objects.create(username="doc2", rol="medico", first_name="Doc", consultorio=consultorio)
+    paciente = Paciente.objects.create(nombre_completo="P3", fecha_nacimiento="2000-01-01", sexo='M', telefono='1', correo='c@c.com', direccion='x', consultorio_asignado=medico)
+    # Cita ocupando horario actual
+    inicio = timezone.now()
+    Cita.objects.create(id='11111111-1111-1111-1111-111111111111', numero_cita='1', paciente=paciente, consultorio=consultorio, medico_asignado=medico, fecha_hora=inicio, duracion=30)
+
+    client.force_login(medico)
+    url = reverse('consultas_crear_sin_cita')
+    data = {
+        'paciente': paciente.pk,
+        'medico': medico.pk,
+        'motivo_consulta': 'test',
+        'programar_para': 'ahora',
+    }
+    before = Consulta.objects.count()
+    resp = client.post(url, data)
+    after = Consulta.objects.count()
+    assert after == before

--- a/consultorio_medico/test_settings.py
+++ b/consultorio_medico/test_settings.py
@@ -1,0 +1,12 @@
+from .settings import *
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+        'ATOMIC_REQUESTS': False,
+    }
+}
+
+MIGRATION_MODULES = {
+    'consultorio_API': None,
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = consultorio_medico.test_settings

--- a/templates/PAGES/consultas/consulta_card.html
+++ b/templates/PAGES/consultas/consulta_card.html
@@ -109,7 +109,7 @@
         </div>
         {% else %}
         <div class="btn-group" role="group">
-          {% if consulta.estado != "finalizada" and consulta.estado != "cancelada" %}
+          {% if consulta.estado != "finalizada" and consulta.estado != "cancelada" and not consulta.medico_en_otro_progreso %}
             <a href="{% url 'consultas_atencion' consulta.pk %}"
                class="btn btn-primary btn-sm">
               <i class="bi bi-clipboard-plus me-1"></i>Atender

--- a/templates/PAGES/consultas/lista.html
+++ b/templates/PAGES/consultas/lista.html
@@ -243,7 +243,7 @@
         <div class="tab-pane fade show active" id="pendientes" role="tabpanel">
           <div class="row row-cols-1 row-cols-lg-2 row-cols-xxl-3 g-4" id="pendientes-container">
             {% for consulta in consultas_pendientes %}
-              {% include 'PAGES/consultas/consulta_card.html' with consulta=consulta usuario=usuario %}
+              {% include 'PAGES/consultas/consulta_card.html' with consulta=consulta usuario=usuario medico_en_otro_progreso=consulta.medico_en_otro_progreso %}
             {% empty %}
               <div class="col-12">
                 <div class="text-center py-5">
@@ -260,7 +260,7 @@
         <div class="tab-pane fade" id="en-progreso" role="tabpanel">
           <div class="row row-cols-1 row-cols-lg-2 row-cols-xxl-3 g-4" id="progreso-container">
             {% for consulta in consultas_en_progreso %}
-              {% include 'PAGES/consultas/consulta_card.html' with consulta=consulta usuario=usuario %}
+              {% include 'PAGES/consultas/consulta_card.html' with consulta=consulta usuario=usuario medico_en_otro_progreso=consulta.medico_en_otro_progreso %}
             {% empty %}
               <div class="col-12">
                 <div class="text-center py-5">
@@ -277,7 +277,7 @@
         <div class="tab-pane fade" id="finalizadas" role="tabpanel">
           <div class="row row-cols-1 row-cols-lg-2 row-cols-xxl-3 g-4" id="finalizadas-container">
             {% for consulta in consultas_finalizadas %}
-              {% include 'PAGES/consultas/consulta_card.html' with consulta=consulta usuario=usuario %}
+              {% include 'PAGES/consultas/consulta_card.html' with consulta=consulta usuario=usuario medico_en_otro_progreso=consulta.medico_en_otro_progreso %}
             {% empty %}
               <div class="col-12">
                 <div class="text-center py-5">
@@ -294,7 +294,7 @@
         <div class="tab-pane fade" id="canceladas" role="tabpanel">
           <div class="row row-cols-1 row-cols-lg-2 row-cols-xxl-3 g-4" id="canceladas-container">
             {% for consulta in consultas_canceladas %}
-              {% include 'PAGES/consultas/consulta_card.html' with consulta=consulta usuario=usuario %}
+              {% include 'PAGES/consultas/consulta_card.html' with consulta=consulta usuario=usuario medico_en_otro_progreso=consulta.medico_en_otro_progreso %}
             {% empty %}
               <div class="col-12">
                 <div class="text-center py-5">


### PR DESCRIPTION
## Summary
- fix medico queryset in `ConsultaSinCitaForm`
- validate overlapping consultations when scheduling now
- provide user to form in `ConsultaSinCitaCreateView`
- prevent multiple consultations in progress for a doctor
- hide "Atender" button when doctor busy
- add basic pytest tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f622dfebc832493a6881169d3c7d5