### PR TITLE
Fix paciente image upload on create

### DIFF
--- a/consultorio_API/forms.py
+++ b/consultorio_API/forms.py
@@ -244,7 +244,7 @@ class PacienteForm(forms.ModelForm):
             'consultorio': forms.Select(attrs={
                 'class': 'form-select'
             }),
-            'foto': forms.FileInput(attrs={
+            'foto': forms.ClearableFileInput(attrs={
                 'class': 'form-control',
                 'accept': 'image/*'
             }),

--- a/consultorio_API/views.py
+++ b/consultorio_API/views.py
@@ -524,7 +524,7 @@ class PacienteDetailView(LoginRequiredMixin, DetailView):
         return ctx
 
 
-class PacienteCreateView(NextRedirectMixin, PacientePermisoMixin, CreateView):
+class PacienteCreateView(PacientePermisoMixin, CreateView):
     model = Paciente
     form_class = PacienteForm
     template_name = "PAGES/pacientes/crear.html"
@@ -537,16 +537,14 @@ class PacienteCreateView(NextRedirectMixin, PacientePermisoMixin, CreateView):
 
     def form_valid(self, form):
         paciente = form.save(commit=False)
-        user = self.request.user
-        if user.rol == "medico":
-            if not user.consultorio:
-                messages.error(self.request, "No tienes consultorio asignado.")
-                return HttpResponseRedirect(self.success_url)
-            paciente.consultorio = user.consultorio
-        else:
-            paciente.consultorio = form.cleaned_data.get("consultorio")
+
+        if self.request.user.rol == "medico" and self.request.user.consultorio:
+            paciente.consultorio = self.request.user.consultorio
+
         paciente.save()
-        return super().form_valid(form)
+        form.save_m2m()
+        messages.success(self.request, "Paciente creado correctamente.")
+        return redirect(self.success_url)
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)


### PR DESCRIPTION
## Summary
- update `PacienteCreateView` to handle consultorio automatically and save images once
- keep form kwargs passing of the user for consultorio filtering
- allow clearing/re-uploading patient photo

## Testing
- `python manage.py makemigrations --check --dry-run`
- `DJANGO_SETTINGS_MODULE=consultorio_medico.test_settings python manage.py migrate --noinput`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688084cf238c83249e12bc392360d54d