### PR TITLE
Fix patient field disabled in new consultation form

### DIFF
--- a/consultorio_API/tests/test_consulta.py
+++ b/consultorio_API/tests/test_consulta.py
@@ -67,7 +67,7 @@ def test_crear_consulta_desde_paciente(client):
     resp = client.get(url)
     content = resp.content.decode()
     assert f'value="{paciente.pk}"' in content
-    assert 'type="hidden"' in content
+    assert 'disabled' in content
 
     data = {
         'paciente': paciente.pk,

--- a/consultorio_API/views_consultas.py
+++ b/consultorio_API/views_consultas.py
@@ -75,5 +75,5 @@ class ConsultaCreateFromPacienteView(ConsultaSinCitaCreateView):
         if paciente_id:
             form.fields['paciente'].queryset = Paciente.objects.filter(pk=paciente_id)
             form.fields['paciente'].empty_label = None
-            form.fields['paciente'].widget = forms.HiddenInput()
+            form.fields['paciente'].disabled = True
         return form


### PR DESCRIPTION
## Summary
- ensure patient is preselected and not editable when creating a consultation from a patient
- adjust tests for disabled patient field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688099fbe1208324ab22d2fe2a022437