### PR TITLE
Enable time-based appointment creation from dashboard calendar

### DIFF
--- a/consultorio_API/api_urls.py
+++ b/consultorio_API/api_urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
+from .viewscitas import citas_json
 
 
 urlpatterns = [
-
+    path('citas-json/', citas_json, name='citas_json'),
 ]

--- a/consultorio_API/viewscitas.py
+++ b/consultorio_API/viewscitas.py
@@ -10,7 +10,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
 from django.views.generic import ListView, CreateView, UpdateView, DeleteView, DetailView
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from datetime import datetime, timedelta, time
+from datetime import datetime, timedelta, time, date
 import json
 import csv
 from consultorio_API.utils_horarios import obtener_horarios_disponibles_para_select
@@ -1102,6 +1102,22 @@ def cambiar_estado_cita(request, cita_id):
         
     except Exception as e:
         return JsonResponse({'success': False, 'message': str(e)}, status=500)
+
+
+@login_required
+def citas_json(request):
+    """Retorna citas futuras en formato JSON para FullCalendar."""
+    qs = Cita.objects.filter(fecha_hora__date__gte=date.today())
+    data = [
+        {
+            'id': str(c.pk),
+            'title': f'Cita – {c.paciente.nombre_completo}',
+            'start': c.fecha_hora.isoformat(),
+            'end': (c.fecha_hora + timedelta(minutes=c.duracion)).isoformat(),
+        }
+        for c in qs
+    ]
+    return JsonResponse(data, safe=False)
 
 
 # ═══════════════════════════════════════════════════════════════

--- a/templates/PAGES/dashboard.html
+++ b/templates/PAGES/dashboard.html
@@ -587,6 +587,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const calendarEl = document.getElementById('calendar');
   calendar = new FullCalendar.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
+    selectable: true,
     locale: 'es',
     height: 650,
     headerToolbar: {
@@ -594,8 +595,15 @@ document.addEventListener('DOMContentLoaded', function () {
       center: 'title',
       right: 'dayGridMonth,timeGridWeek,timeGridDay'
     },
+    validRange: {
+      start: new Date().toISOString().slice(0, 10)
+    },
     eventTimeFormat: { hour: '2-digit', minute: '2-digit', meridiem: false },
-    events: {{ eventos_json|safe }},
+    events: '/api/citas-json/',
+    selectOverlap: false,
+    selectAllow: function(selectInfo) {
+      return selectInfo.start >= new Date();
+    },
     eventClick: function(info) {
       mostrarDetalleCita(info.event.id);
     },
@@ -604,11 +612,23 @@ document.addEventListener('DOMContentLoaded', function () {
       info.el.title = info.event.title + ' - ' + (info.event.extendedProps.motivo || 'Consulta general');
     },
     dateClick: function(info) {
-      // Redirigir a crear cita en esa fecha
-      window.location.href = `{% url 'citas_crear' %}?fecha=${info.dateStr}`;
+      redirigirACrearCita(info.dateStr, null);
+    },
+    select: function(info) {
+      const fecha = info.startStr.slice(0, 10);
+      const hora = info.startStr.slice(11, 16);
+      redirigirACrearCita(fecha, hora);
     }
   });
   calendar.render();
+
+  function redirigirACrearCita(fecha, hora) {
+    let url = `/citas/crear/?fecha=${fecha}`;
+    if (hora) {
+      url += `&hora=${hora}`;
+    }
+    window.location.href = url;
+  }
 
   /* ---------- GRÁFICA: ESTADOS ---------- */
   chartEstados = new Chart(


### PR DESCRIPTION
## Summary
- expose calendar data via `citas-json` API endpoint
- pre-fill date and hour when opening `CitaCreateView`
- block past dates/hours when creating appointments
- update dashboard calendar to allow selecting free slots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68809950c5088324a937163c0d58f0f6