### PR TITLE
Add return redirect parameter for new record forms

### DIFF
--- a/consultorio_API/views.py
+++ b/consultorio_API/views.py
@@ -36,6 +36,7 @@ from .models import (
 )
 from .forms import *
 from .utils import redirect_next
+from django.utils.http import url_has_allowed_host_and_scheme
 
 
 def doctor_tiene_consulta_en_progreso(medico):
@@ -50,7 +51,12 @@ class NextRedirectMixin:
         return self.request.POST.get("next") or self.request.GET.get("next")
 
     def get_success_url(self):
-        return self.get_next_url() or super().get_success_url()
+        next_url = self.get_next_url()
+        if next_url and url_has_allowed_host_and_scheme(
+            next_url, allowed_hosts={self.request.get_host()}
+        ):
+            return next_url
+        return super().get_success_url()
 
 # ═══════════════════════════════════════════════════════════════
 # 🔐 LOGIN Y DASHBOARD
@@ -2279,7 +2285,7 @@ class ConsultaSinCitaCreateView(NextRedirectMixin, LoginRequiredMixin, CreateVie
                 f'No hay conflictos de horario.'
             )
         
-        return redirect(self.success_url)
+        return redirect(self.get_success_url())
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/templates/PAGES/citas/crear.html
+++ b/templates/PAGES/citas/crear.html
@@ -121,6 +121,7 @@
                 <div class="card-body">
                     <form method="post" novalidate id="citaForm">
                         {% csrf_token %}
+                        <input type="hidden" name="next" value="{{ request.GET.next }}">
 
                         <!-- Información del Paciente -->
                         <div class="form-section">

--- a/templates/PAGES/consultas/crear_sin_cita.html
+++ b/templates/PAGES/consultas/crear_sin_cita.html
@@ -182,7 +182,7 @@
                         {{ form.observaciones_iniciales }}
                     </div>
 
-                    <input type="hidden" name="next" value="{{ next }}">
+                    <input type="hidden" name="next" value="{{ request.GET.next }}">
                     <!-- Asegurar que es sin cita -->
                     <input type="hidden" name="tipo" value="sin_cita">
 

--- a/templates/PAGES/dashboard.html
+++ b/templates/PAGES/dashboard.html
@@ -251,7 +251,7 @@
           <div class="row g-3">
             {% if usuario.rol == "admin" or usuario.rol == "medico" or usuario.rol == "asistente" %}
             <div class="col-md-2 col-6">
-              <a href="{% url 'citas_crear' %}" class="btn btn-outline-primary quick-action-btn w-100">
+              <a href="{% url 'citas_crear' %}?next={{ request.path }}" class="btn btn-outline-primary quick-action-btn w-100">
                 <i class="bi bi-calendar-plus fs-3 mb-1"></i>
                 <small>Nueva Cita</small>
               </a>
@@ -260,7 +260,7 @@
             
             {% if usuario.rol == "admin" or usuario.rol == "medico" %}
             <div class="col-md-2 col-6">
-              <a href="{% url 'consultas_crear_sin_cita' %}" class="btn btn-outline-success quick-action-btn w-100">
+              <a href="{% url 'consultas_crear_sin_cita' %}?next={{ request.path }}" class="btn btn-outline-success quick-action-btn w-100">
                 <i class="bi bi-clipboard-plus fs-3 mb-1"></i>
                 <small>Nueva Consulta</small>
               </a>
@@ -605,7 +605,7 @@ document.addEventListener('DOMContentLoaded', function () {
     },
     dateClick: function(info) {
       // Redirigir a crear cita en esa fecha
-      window.location.href = `{% url 'citas_crear' %}?fecha=${info.dateStr}`;
+      window.location.href = `{% url 'citas_crear' %}?fecha=${info.dateStr}&next={{ request.path }}`;
     }
   });
   calendar.render();


### PR DESCRIPTION
## Summary
- handle `?next` in redirect mixin for safety
- allow dashboard quick actions to include `next` URL
- preserve next query param when creating citas or consultas

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68809f50edf88324901171073fcc2976