### PR TITLE
Add return redirect parameter for new record forms

### DIFF
--- a/templates/PAGES/citas/crear.html
+++ b/templates/PAGES/citas/crear.html
@@ -106,7 +106,7 @@
                     <h2><i class="fas fa-calendar-plus me-2"></i>{{ titulo }}</h2>
                     <p class="text-muted mb-0">Complete la información de la cita</p>
                 </div>
-                <a href="{% url 'citas_lista' %}" class="btn btn-secondary">
+                <a href="{{ next }}" class="btn btn-secondary">
                     <i class="fas fa-arrow-left me-2"></i>Volver
                 </a>
             </div>
@@ -121,6 +121,7 @@
                 <div class="card-body">
                     <form method="post" novalidate id="citaForm">
                         {% csrf_token %}
+                        <input type="hidden" name="next" value="{{ request.POST.next|default:request.GET.next }}">
 
                         <!-- Información del Paciente -->
                         <div class="form-section">
@@ -341,7 +342,7 @@
 
                         <!-- Botones -->
                         <div class="d-flex justify-content-end gap-2">
-                            <a href="{% url 'citas_lista' %}" class="btn btn-secondary">
+                            <a href="{{ next }}" class="btn btn-secondary">
                                 <i class="fas fa-times me-2"></i>Cancelar
                             </a>
                             <button type="submit" class="btn btn-primary" id="submitBtn">

--- a/templates/PAGES/consultas/crear_sin_cita.html
+++ b/templates/PAGES/consultas/crear_sin_cita.html
@@ -182,7 +182,7 @@
                         {{ form.observaciones_iniciales }}
                     </div>
 
-                    <input type="hidden" name="next" value="{{ next }}">
+                    <input type="hidden" name="next" value="{{ request.POST.next|default:request.GET.next }}">
                     <!-- Asegurar que es sin cita -->
                     <input type="hidden" name="tipo" value="sin_cita">
 

--- a/templates/PAGES/dashboard.html
+++ b/templates/PAGES/dashboard.html
@@ -251,7 +251,7 @@
           <div class="row g-3">
             {% if usuario.rol == "admin" or usuario.rol == "medico" or usuario.rol == "asistente" %}
             <div class="col-md-2 col-6">
-              <a href="{% url 'citas_crear' %}" class="btn btn-outline-primary quick-action-btn w-100">
+              <a href="{% url 'citas_crear' %}?next={{ request.path }}" class="btn btn-outline-primary quick-action-btn w-100">
                 <i class="bi bi-calendar-plus fs-3 mb-1"></i>
                 <small>Nueva Cita</small>
               </a>
@@ -260,7 +260,7 @@
             
             {% if usuario.rol == "admin" or usuario.rol == "medico" %}
             <div class="col-md-2 col-6">
-              <a href="{% url 'consultas_crear_sin_cita' %}" class="btn btn-outline-success quick-action-btn w-100">
+              <a href="{% url 'consultas_crear_sin_cita' %}?next={{ request.path }}" class="btn btn-outline-success quick-action-btn w-100">
                 <i class="bi bi-clipboard-plus fs-3 mb-1"></i>
                 <small>Nueva Consulta</small>
               </a>
@@ -605,7 +605,7 @@ document.addEventListener('DOMContentLoaded', function () {
     },
     dateClick: function(info) {
       // Redirigir a crear cita en esa fecha
-      window.location.href = `{% url 'citas_crear' %}?fecha=${info.dateStr}`;
+      window.location.href = `{% url 'citas_crear' %}?fecha=${info.dateStr}&next={{ request.path }}`;
     }
   });
   calendar.render();


### PR DESCRIPTION
## Summary
- handle `?next` in redirect mixin for safety
- allow dashboard quick actions to include `next` URL
- preserve next query param when creating citas or consultas
- use next URL for cancel/back links in new forms

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'consultorio_medico')*

------
https://chatgpt.com/codex/tasks/task_e_68809f50edf88324901171073fcc2976