### PR TITLE
Add vital signs registrar tracking

### DIFF
--- a/templates/PAGES/consultas/detalle.html
+++ b/templates/PAGES/consultas/detalle.html
@@ -183,9 +183,10 @@
                 </p>
               </div>
             </div>
-            <small class="text-muted">
-              Registrado: {{ signos_vitales.fecha_registro|date:"d/m/Y H:i" }}
-            </small>
+            <p class="text-muted fst-italic mb-1">
+              Registrados por: {{ signos_vitales.registrado_por.get_full_name }}
+              el {{ signos_vitales.fecha_registro|date:"d/m/Y H:i" }}
+            </p>
             <div class="mt-3 d-grid gap-2">
               <a href="{% url 'signos_detalle' signos_vitales.pk %}" class="btn btn-sm btn-outline-info">
                 <i class="bi bi-eye me-1"></i>Ver Detalles


### PR DESCRIPTION
## Summary
- record the user who captured vital signs via `registrado_por`
- auto-fill `registrado_por` during save
- ensure precheck assigns the current user
- display registrar name in consulta detail

## Testing
- `python manage.py makemigrations` *(fails: Can't connect to local MySQL server)*
- `python manage.py migrate --noinput` *(fails: Can't connect to local MySQL server)*
- `pytest -q` *(fails: ImproperlyConfigured: Requested setting DATABASES, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6881546b94208324aee16c6230a0fb9c