### PR TITLE
Implement preview modal for receta

### DIFF
--- a/consultorio_API/urls.py
+++ b/consultorio_API/urls.py
@@ -14,7 +14,8 @@ from .views_consultas import (
 )
 from django.contrib.auth.views import LogoutView
 from .views import CitaCreateView, Receta
-from consultorio_API import views, viewscitas 
+from consultorio_API import views, viewscitas
+from consultorio_API.views_recetas import RecetaPreviewView
 
 urlpatterns = [
       # LOGIN Y LOGOUT
@@ -103,8 +104,9 @@ urlpatterns = [
    path('notificaciones/marcar-todas-leidas/', views.marcar_todas_notificaciones_leidas, name='marcar_todas_notificaciones_leidas'),
     path('notificaciones/count/', views.notificaciones_count_ajax, name='notificaciones_count'),
     
-    # PDF
+    # PDF y previsualización de recetas
     path('recetas/<int:receta_id>/pdf/', views.receta_pdf_view, name='receta_pdf'),
+    path("recetas/<uuid:pk>/preview/", RecetaPreviewView.as_view(), name="receta_preview"),
     path('citas/exportar-csv/', viewscitas.exportar_citas_csv, name='exportar_citas_csv'),  # CAMBIAR
     
     

--- a/consultorio_API/views_recetas.py
+++ b/consultorio_API/views_recetas.py
@@ -1,0 +1,19 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import HttpResponseForbidden
+from django.views.generic import DetailView
+
+from .models import Receta
+
+
+class RecetaPreviewView(LoginRequiredMixin, DetailView):
+    """Previsualización simple de una receta para mostrar en un modal."""
+
+    model = Receta
+    template_name = "PAGES/recetas/_preview.html"
+    context_object_name = "receta"
+
+    def dispatch(self, request, *args, **kwargs):
+        receta = self.get_object()
+        if not request.user.has_perm("consultorio.view_receta"):
+            return HttpResponseForbidden()
+        return super().dispatch(request, *args, **kwargs)

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,7 @@
+.receta-container { font-size: .95rem; }
+@media print {
+  body *        { visibility: hidden; }
+  #modalReceta  { position: static !important; }
+  #modalReceta *{ visibility: visible; }
+  #modalReceta .modal-footer { display:none; }
+}

--- a/templates/PAGES/consultas/consulta_card.html
+++ b/templates/PAGES/consultas/consulta_card.html
@@ -169,8 +169,10 @@
             {% if usuario.rol != 'asistente' %}
               {% if consulta.receta %}
                 <li>
-                  <a class="dropdown-item" href="{% url 'receta_pdf' consulta.receta.pk %}">
-                    <i class="bi bi-download me-2"></i>Descargar Receta
+                  <a class="dropdown-item btn-preview-receta" href="#"
+                     data-preview-url="{% url 'receta_preview' consulta.receta.pk %}"
+                     data-pdf-url="{% url 'receta_pdf' consulta.receta.pk %}">
+                    <i class="bi bi-eye me-2"></i>Ver Receta
                   </a>
                 </li>
               {% else %}

--- a/templates/PAGES/consultas/detalle.html
+++ b/templates/PAGES/consultas/detalle.html
@@ -35,8 +35,11 @@
         </a>
       {% endif %}
       {% if receta and receta.medicamentos.exists %}
-        <a href="{% url 'receta_pdf' receta.pk %}" class="btn btn-success me-1">
-          <i class="bi bi-printer me-1"></i>Imprimir
+        <a href="#"
+           class="btn btn-outline-primary btn-preview-receta me-1"
+           data-preview-url="{% url 'receta_preview' receta.pk %}"
+           data-pdf-url="{% url 'receta_pdf' receta.pk %}">
+          <i class="bi bi-eye me-1"></i>Ver Receta
         </a>
       {% endif %}
       {% if consulta.estado == 'espera' or consulta.estado == 'en_progreso' %}
@@ -224,8 +227,10 @@
               Receta emitida el {{ receta.fecha_emision|date:"d/m/Y" }}
             </p>
             {% if receta.medicamentos.exists %}
-              <a href="{% url 'receta_pdf' receta.pk %}" class="btn btn-sm btn-outline-success w-100 mb-3">
-                <i class="bi bi-download me-1"></i>Descargar PDF
+              <a href="#" class="btn btn-sm btn-outline-primary btn-preview-receta w-100 mb-3"
+                 data-preview-url="{% url 'receta_preview' receta.pk %}"
+                 data-pdf-url="{% url 'receta_pdf' receta.pk %}">
+                <i class="bi bi-eye me-1"></i>Ver Receta
               </a>
             {% endif %}
 

--- a/templates/PAGES/pacientes/detalle.html
+++ b/templates/PAGES/pacientes/detalle.html
@@ -431,8 +431,10 @@
                             
                             {% if c.receta %}
                               <li>
-                                <a class="dropdown-item" href="{% url 'receta_pdf' c.receta.pk %}">
-                                  <i class="bi bi-download me-2 text-success"></i>Descargar Receta
+                                <a class="dropdown-item btn-preview-receta" href="#"
+                                   data-preview-url="{% url 'receta_preview' c.receta.pk %}"
+                                   data-pdf-url="{% url 'receta_pdf' c.receta.pk %}">
+                                  <i class="bi bi-eye me-2 text-success"></i>Ver Receta
                                 </a>
                               </li>
                             {% else %}

--- a/templates/PAGES/recetas/_preview.html
+++ b/templates/PAGES/recetas/_preview.html
@@ -1,0 +1,16 @@
+<div class="receta-container px-3 py-2">
+  <h4 class="fw-bold mb-0">{{ receta.consulta.medico }}</h4>
+  <small class="text-muted">{{ receta.fecha|date:"d/m/Y H:i" }}</small>
+  <hr>
+  <p><strong>Paciente:</strong> {{ receta.consulta.paciente }}</p>
+  <p><strong>Diagnóstico:</strong> {{ receta.diagnostico }}</p>
+  <h5 class="mt-3">Medicamentos</h5>
+  <ul class="mb-2">
+    {% for m in receta.medicamentos.all %}
+      <li>{{ m.nombre }} – {{ m.indicaciones }}</li>
+    {% empty %}
+      <li>No hay medicamentos.</li>
+    {% endfor %}
+  </ul>
+  <p class="fst-italic">Firma electrónica del médico</p>
+</div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -711,6 +711,57 @@
         }
     </script>
 
+    <div class="modal fade" id="modalReceta" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Receta médica</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <div class="text-center text-muted py-4">Cargando…</div>
+          </div>
+          <div class="modal-footer">
+            <a id="modalRecetaDownload" class="btn btn-success" target="_blank">
+              Descargar PDF
+            </a>
+            <button id="modalRecetaPrint" class="btn btn-primary">
+              Imprimir
+            </button>
+            <button class="btn btn-secondary" data-bs-dismiss="modal">
+              Cerrar
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+document.addEventListener("DOMContentLoaded", () => {
+  const modalEl   = document.getElementById("modalReceta");
+  const modalBody = modalEl.querySelector(".modal-body");
+  const btnPrint  = document.getElementById("modalRecetaPrint");
+  const linkPdf   = document.getElementById("modalRecetaDownload");
+
+  document.querySelectorAll(".btn-preview-receta").forEach(btn => {
+    btn.addEventListener("click", ev => {
+      ev.preventDefault();
+
+      modalBody.innerHTML = '<div class="text-center text-muted py-4">Cargando…</div>';
+      linkPdf.href = btn.dataset.pdfUrl;
+
+      fetch(btn.dataset.previewUrl)
+        .then(r => r.text())
+        .then(html => { modalBody.innerHTML = html; });
+
+      btnPrint.onclick = () => window.print();
+
+      new bootstrap.Modal(modalEl).show();
+    });
+  });
+});
+    </script>
+
     {% block scripts %}{% endblock %}
     {% block extra_js %}{% endblock %}
 </body>


### PR DESCRIPTION
## Summary
- show recipe preview via RecetaPreviewView
- create template for preview content
- add modal markup and JS handlers
- show preview button in consulta and paciente views
- minimal print CSS for the modal

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: AppRegistryNotReady)*

------
https://chatgpt.com/codex/tasks/task_e_6881be334fac8324a13cd1db04efaa4e