### PR TITLE
Fix assistant restrictions on consultations

### DIFF
--- a/consultorio_API/views_consultas.py
+++ b/consultorio_API/views_consultas.py
@@ -4,6 +4,7 @@ from django.shortcuts import get_object_or_404, redirect
 from django.views.decorators.http import require_POST
 from django.views.generic.edit import CreateView
 from django.urls import reverse_lazy
+from django.http import HttpResponseForbidden
 from django import forms
 
 from .forms import ConsultaSinCitaForm
@@ -18,6 +19,8 @@ def puede_modificar(user, consulta):
 @login_required
 @require_POST
 def cancelar_consulta(request, pk):
+    if request.user.rol == "asistente":
+        return HttpResponseForbidden("No tienes permiso para cancelar consultas.")
     consulta = get_object_or_404(Consulta, pk=pk)
     if not puede_modificar(request.user, consulta):
         messages.error(request, "Acción no autorizada.")
@@ -37,6 +40,9 @@ def cancelar_consulta(request, pk):
 @login_required
 @require_POST
 def eliminar_consulta(request, pk):
+    if request.user.rol == "asistente":
+        messages.error(request, "No puedes eliminar consultas.")
+        return redirect("consultas_lista")
     consulta = get_object_or_404(Consulta, pk=pk)
     if not puede_modificar(request.user, consulta):
         messages.error(request, "Acción no autorizada.")

--- a/templates/PAGES/consultas/consulta_card.html
+++ b/templates/PAGES/consultas/consulta_card.html
@@ -184,28 +184,30 @@
               {% endif %}
             {% endif %}
             
-            {% if consulta.estado == "espera" or consulta.estado == "en_progreso" %}
-              <li>
-                <form method="post" action="{% url 'consulta_cancelar' consulta.pk %}" onsubmit="return confirm('¿Estás seguro de eliminar?');">
-                  {% csrf_token %}
-                  <input type="hidden" name="next" value="{{ request.get_full_path }}">
-                  <button class="dropdown-item text-warning">
-                    <i class="bi bi-x-circle me-2"></i>Cancelar
-                  </button>
-                </form>
-              </li>
-            {% endif %}
+            {% if usuario.rol != 'asistente' %}
+              {% if consulta.estado == "espera" or consulta.estado == "en_progreso" %}
+                <li>
+                  <form method="post" action="{% url 'consulta_cancelar' consulta.pk %}" onsubmit="return confirm('¿Estás seguro de eliminar?');">
+                    {% csrf_token %}
+                    <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                    <button class="dropdown-item text-warning">
+                      <i class="bi bi-x-circle me-2"></i>Cancelar
+                    </button>
+                  </form>
+                </li>
+              {% endif %}
 
-            {% if consulta.estado != "en_progreso" %}
-              <li>
-                <form method="post" action="{% url 'consulta_eliminar' consulta.pk %}" onsubmit="return confirm('¿Estás seguro de eliminar?');">
-                  {% csrf_token %}
-                  <input type="hidden" name="next" value="{{ request.get_full_path }}">
-                  <button class="dropdown-item text-danger">
-                    <i class="bi bi-trash me-2"></i>Eliminar
-                  </button>
-                </form>
-              </li>
+              {% if consulta.estado != "en_progreso" %}
+                <li>
+                  <form method="post" action="{% url 'consulta_eliminar' consulta.pk %}" onsubmit="return confirm('¿Estás seguro de eliminar?');">
+                    {% csrf_token %}
+                    <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                    <button class="dropdown-item text-danger">
+                      <i class="bi bi-trash me-2"></i>Eliminar
+                    </button>
+                  </form>
+                </li>
+              {% endif %}
             {% endif %}
           </ul>
         </div>

--- a/templates/PAGES/signos/detalle.html
+++ b/templates/PAGES/signos/detalle.html
@@ -40,7 +40,7 @@
     </div>
     <div class="col-md-4 text-md-end mt-3 mt-md-0">
       <div class="d-flex gap-2 justify-content-md-end">
-        <a href="{{ volver_a }}" class="btn btn-outline-secondary">
+        <a class="btn btn-outline-secondary" href="{% url 'consultas_lista' %}">
           <i class="bi bi-arrow-left me-1"></i>Volver
         </a>
         {% if usuario.rol in 'medico,asistente,admin' %}


### PR DESCRIPTION
## Summary
- update navigation from vital signs detail to consultations list
- hide cancel/delete actions from assistants
- forbid assistants from canceling or deleting consultations server-side
- adjust default back link for vital signs detail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881cbff9ec48324882b47f6146a206f