### PR TITLE
Fix recipe print layout

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,7 +1,1 @@
 .receta-container { font-size: .95rem; }
-@media print {
-  body *        { visibility: hidden; }
-  #modalReceta  { position: static !important; }
-  #modalReceta *{ visibility: visible; }
-  #modalReceta .modal-footer { display:none; }
-}

--- a/static/css/print_receta.css
+++ b/static/css/print_receta.css
@@ -1,0 +1,37 @@
+/* ====  SOLO PARA IMPRESIÓN DE RECETA  ==== */
+@media print {
+
+  /* 0. Márgenes y tamaño de página  */
+  @page {
+      size: A5 portrait;            /* ajusta a formato deseado  */
+      margin: 12mm;                 /* margen estándar recetario */
+  }
+
+  /* 1. Ocultar TODO el resto del documento */
+  body *               { visibility: hidden !important; }
+  body, html           { background: #fff !important; }
+
+  /* 2. Mostrar solo la receta */
+  #modalReceta,                       /* contenedor modal */
+  #modalReceta .receta-container,
+  #modalReceta .receta-container *    /* hijos de la receta */
+  { visibility: visible !important; }
+
+  /* 3. Colocar la receta en posición normal para ocupar toda la página */
+  #modalReceta {
+      position: static !important;   /* quita fija/transform de Bootstrap */
+      inset: 0 !important;
+      transform: none !important;
+  }
+
+  /* 4. Elimina cabecera / pie del modal y sombras */
+  #modalReceta .modal-dialog,
+  #modalReceta .modal-content        { box-shadow: none !important; }
+
+  #modalReceta .modal-header,
+  #modalReceta .modal-footer         { display: none !important; }
+
+  /* 5. Evitar cortes internos */
+  .receta-container                  { break-inside: avoid; }
+
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
     <!-- Custom CSS -->
     <link href="{% static 'css/custom.css' %}" rel="stylesheet">
+    <link rel="stylesheet" href="{% static 'css/print_receta.css' %}" media="print">
     
     <style>
         :root {
@@ -754,7 +755,9 @@ document.addEventListener("DOMContentLoaded", () => {
         .then(r => r.text())
         .then(html => { modalBody.innerHTML = html; });
 
-      btnPrint.onclick = () => window.print();
+      btnPrint.onclick = () => {
+        window.setTimeout(() => window.print(), 100);
+      };
 
       new bootstrap.Modal(modalEl).show();
     });


### PR DESCRIPTION
## Summary
- add print_receta.css to style the recipe modal when printing
- load print_receta.css from the base template
- delay printing slightly to ensure modal content is ready
- keep custom.css for on-screen styles only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881d6435af083248a4fe1aeef051031