### PR TITLE
Limit assistant roles

### DIFF
--- a/templates/PAGES/citas/lista.html
+++ b/templates/PAGES/citas/lista.html
@@ -505,7 +505,7 @@
                                         <i class="bi bi-hand-index"></i> Tomar
                                     </a>
                                     {% endif %}
-                                    {% if permisos.puede_asignar %}
+                                    {% if permisos.puede_asignar and usuario.rol != 'asistente' %}
                                     <button type="button" class="btn btn-sm btn-primary btn-action"
                                             onclick="asignarMedico('{{ cita.pk }}')">
                                         <i class="bi bi-person-plus"></i> Asignar

--- a/templates/PAGES/citas/partials/tabla_citas.html
+++ b/templates/PAGES/citas/partials/tabla_citas.html
@@ -82,8 +82,8 @@
                                     </a>
                                 {% endif %}
                                 
-                                {% if permisos.puede_asignar %}
-                                    <button type="button" class="btn btn-sm btn-primary" 
+                                {% if permisos.puede_asignar and usuario.rol != 'asistente' %}
+                                    <button type="button" class="btn btn-sm btn-primary"
                                             onclick="asignarMedico('{{ cita.id }}')" title="Asignar médico">
                                         <i class="bi bi-person-plus"></i>
                                     </button>

--- a/templates/PAGES/citas/partials/turnos_cola.html
+++ b/templates/PAGES/citas/partials/turnos_cola.html
@@ -160,32 +160,8 @@
 
                     <!-- Acciones para asistentes -->
                     {% if usuario.rol == 'asistente' %}
-                        <!-- Asignar médico -->
-                        {% if not cita.medico_asignado and cita.estado in 'programada,confirmada' %}
-                        <div class="dropdown d-inline-block">
-                            <button class="btn-action btn-primary-action dropdown-toggle"
-                                     type="button"
-                                     data-bs-toggle="dropdown">
-                                <i class="bi bi-person-plus"></i>
-                                Asignar Médico
-                            </button>
-                            <ul class="dropdown-menu">
-                                {% for medico in cita.consultorio.usuarios_asignados.all %}
-                                {% if medico.rol == 'medico' and medico.is_active %}
-                                <li>
-                                    <a class="dropdown-item" href="#"
-                                        onclick="asignarMedico('{{ cita.id }}', '{{ medico.id }}', '{{ medico.get_full_name }}')">
-                                        <i class="bi bi-person-check me-2"></i>
-                                        Dr. {{ medico.get_full_name }}
-                                    </a>
-                                </li>
-                                {% endif %}
-                                {% empty %}
-                                <li><span class="dropdown-item-text text-muted">No hay médicos disponibles</span></li>
-                                {% endfor %}
-                            </ul>
-                        </div>
-                        {% endif %}
+                        {# Botón de asignar médico oculto para asistentes #}
+                        {% if false %}{% endif %}
 
                         <!-- Cambiar estado -->
                         {% if cita.estado == 'programada' %}

--- a/templates/PAGES/consultas/lista.html
+++ b/templates/PAGES/consultas/lista.html
@@ -37,6 +37,7 @@
           <i class="bi bi-x"></i>
         </button>
       </div>
+      {% if usuario.rol != 'asistente' %}
       <div class="dropdown">
         <button class="btn btn-success dropdown-toggle" type="button" data-bs-toggle="dropdown">
           <i class="bi bi-plus-circle me-1"></i>Nueva Consulta
@@ -54,6 +55,7 @@
           </li>
         </ul>
       </div>
+      {% endif %}
       
       <!-- BOTÓN PARA RECARGAR PÁGINA -->
       <button class="btn btn-outline-primary" onclick="location.reload()">


### PR DESCRIPTION
## Summary
- restrict assistants from creating, deleting and cancelling consultas
- redirect assistants creating citas back to the list
- hide 'Nueva Consulta' button for assistants
- hide Asignar buttons for assistants in citas views

## Testing
- `pytest -q` *(fails: ImproperlyConfigured)*

------
https://chatgpt.com/codex/tasks/task_e_6881d52eabb08324b8c60dd1db211dc0