### PR TITLE
Add notes section to prescription template

### DIFF
--- a/static/css/receta.css
+++ b/static/css/receta.css
@@ -2,13 +2,13 @@
 @page  { size: A5 portrait; margin: 10mm; }
 body   { margin:0; background:#fff; }
 
-.receta      { width: 128mm; margin:0 auto; font:11pt/1.3 "Helvetica","Arial",sans-serif; color:#000; }
+.receta      { width: 128mm; margin:0 auto; font-size:12pt; line-height:1.45; font-family:"Helvetica","Arial",sans-serif; color:#000; }
 .hdr         { text-align:center; margin-bottom:4mm; }
 .logo        { max-height:18mm; display:block; margin:0 auto 2mm; }
 .sub         { font-size:10pt; display:block; letter-spacing:.4px; margin-bottom:1mm; }
-.grid-2      { display:grid; grid-template-columns:1fr 1fr; gap:1mm; margin-bottom:2.5mm; }
+.grid-2      { display:grid; grid-template-columns:1fr 1fr; gap:1mm; margin-bottom:4mm; }
 .right       { text-align:right; }
-.section-title{ font-size:11pt; margin:3mm 0 1mm; text-align:center; text-decoration:underline; }
+.section-title{ font-size:11pt; margin:4mm 0 2mm; text-align:center; text-decoration:underline; }
 
 .tbl-signos  { width:100%; border-collapse:collapse; font-size:10pt; margin-bottom:2mm;}
 .tbl-signos th,
@@ -17,6 +17,14 @@ body   { margin:0; background:#fff; }
 .aler        { margin:1mm 0 3mm; }
 
 .lista-meds  { font-size:10pt; margin:0 0 4mm 0; padding-left:4mm; }
-.lista-meds li{ margin-bottom:1.5mm; }
+.lista-meds li{ margin-bottom:2.5mm; }
+
+/* === BLOQUE NOTAS === */
+.notas           { margin:4mm 0 5mm; }
+.notas .line     {
+   border-bottom:0.25pt dotted #999;
+   height:8mm;
+   margin-bottom:2mm;
+}
 
 .pie         { text-align:center; font-size:9pt; border-top:0.4pt dotted #666; padding-top:2mm; }

--- a/templates/PAGES/recetas/_receta_base.html
+++ b/templates/PAGES/recetas/_receta_base.html
@@ -78,6 +78,14 @@
      {% endfor %}
   </ol>
 
+  <!-- NOTAS DEL MÉDICO -->
+  <h4 class="section-title">Observaciones</h4>
+  <div class="notas">
+     {% for i in "12345"|make_list %}
+         <div class="line"></div>
+     {% endfor %}
+  </div>
+
   <!-- PIE -->
   <footer class="pie">
     DR. {{ receta.consulta.medico }}<br>


### PR DESCRIPTION
## Summary
- add optional 'Observaciones' lines after medicamentos list in the A5 prescription
- adjust fonts and spacing to improve readability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f088ac8c8324aa84552af2a810af