### PR TITLE
Fix recipe preview layout and fill missing data

### DIFF
--- a/consultorio_API/views_recetas.py
+++ b/consultorio_API/views_recetas.py
@@ -2,6 +2,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponseForbidden
 from django.views.generic import DetailView
 from django.utils import timezone
+from datetime import timedelta
 
 from .models import Receta
 
@@ -17,6 +18,10 @@ class RecetaPreviewView(LoginRequiredMixin, DetailView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx["show_logo"] = True
+        receta = ctx["receta"]
+        receta.fecha_validez = receta.valido_hasta or (
+            receta.fecha_emision + timedelta(days=2)
+        )
         return ctx
 
     def dispatch(self, request, *args, **kwargs):

--- a/static/css/receta.css
+++ b/static/css/receta.css
@@ -2,29 +2,33 @@
 @page  { size: A5 portrait; margin: 10mm; }
 body   { margin:0; background:#fff; }
 
-.receta      { width: 128mm; margin:0 auto; font-size:12pt; line-height:1.45; font-family:"Helvetica","Arial",sans-serif; color:#000; }
+.receta      { width:126mm; margin:0 auto; font-size:11pt; line-height:1.35; font-family:"Helvetica","Arial",sans-serif; color:#000; break-inside:avoid; page-break-inside:avoid; }
 .hdr         { text-align:center; margin-bottom:4mm; }
 .logo        { max-height:18mm; display:block; margin:0 auto 2mm; }
 .sub         { font-size:10pt; display:block; letter-spacing:.4px; margin-bottom:1mm; }
 .grid-2      { display:grid; grid-template-columns:1fr 1fr; gap:1mm; margin-bottom:4mm; }
 .right       { text-align:right; }
-.section-title{ font-size:11pt; margin:4mm 0 2mm; text-align:center; text-decoration:underline; }
+.section-title{ font-size:11pt; margin:3mm 0 1.5mm; text-align:center; text-decoration:underline; }
 
-.tbl-signos  { width:100%; border-collapse:collapse; font-size:10pt; margin-bottom:2mm;}
+.tbl-signos  { width:100%; border-collapse:collapse; font-size:10pt; margin-bottom:1.5mm; }
 .tbl-signos th,
 .tbl-signos td{ border:1px solid #000; padding:1mm 2mm; text-align:center; }
 
 .aler        { margin:1mm 0 3mm; }
 
 .lista-meds  { font-size:10pt; margin:0 0 4mm 0; padding-left:4mm; }
-.lista-meds li{ margin-bottom:2.5mm; }
+.lista-meds li{ margin-bottom:1.2mm; }
 
 /* === BLOQUE NOTAS === */
 .notas           { margin:4mm 0 5mm; }
 .notas .line     {
    border-bottom:0.25pt dotted #999;
-   height:8mm;
-   margin-bottom:2mm;
+   height:6mm;
+   margin-bottom:1.5mm;
 }
 
 .pie         { text-align:center; font-size:9pt; border-top:0.4pt dotted #666; padding-top:2mm; }
+
+@media print {
+  .receta { page-break-after: avoid; }
+}

--- a/templates/PAGES/recetas/_receta_base.html
+++ b/templates/PAGES/recetas/_receta_base.html
@@ -23,14 +23,20 @@
 
   <!-- FECHAS -->
   <section class="grid-2">
-      <div><strong>Fecha:</strong> {{ receta.fecha|date:"d/m/Y" }}</div>
-      <div class="right"><strong>Válido hasta:</strong> {{ receta.fecha|date:"d/m/Y" }}</div>
+      <div><strong>Fecha:</strong> {{ receta.fecha_emision|date:"d/m/Y" }}</div>
+      <div class="right"><strong>Válido hasta:</strong>
+          {{ receta.fecha_validez|default_if_none:receta.fecha_emision|date:"d/m/Y" }}
+      </div>
   </section>
 
   <!-- MÉDICO -->
   <section class="grid-2">
-      <div><strong>Nombre y firma del médico:</strong> DR. {{ receta.consulta.medico }}</div>
-      <div class="right"><strong>Cédula Prof.:</strong> {{ receta.consulta.medico.cedula }}</div>
+      <div><strong>Nombre y firma del médico:</strong>
+          DR. {{ receta.consulta.medico.get_full_name }}
+      </div>
+      <div class="right"><strong>Cédula Prof.:</strong>
+          {{ receta.consulta.medico.cedula_profesional|default:"—" }}
+      </div>
   </section>
 
   <!-- SIGNOS + ALERGIAS -->
@@ -81,15 +87,16 @@
   <!-- NOTAS DEL MÉDICO -->
   <h4 class="section-title">Observaciones</h4>
   <div class="notas">
-     {% for i in "12345"|make_list %}
+     {% for i in "123"|make_list %}
          <div class="line"></div>
      {% endfor %}
   </div>
 
   <!-- PIE -->
   <footer class="pie">
-    DR. {{ receta.consulta.medico }}<br>
-    CÉDULA PROFESIONAL: {{ receta.consulta.medico.cedula }} – INSTITUCIÓN: {{ receta.consulta.medico.institucion }}<br>
-    DIRECCIÓN: {{ receta.consulta.medico.direccion }}
+    DR. {{ receta.consulta.medico.get_full_name }}<br>
+    CÉDULA PROFESIONAL: {{ receta.consulta.medico.cedula_profesional|default:"—" }} –
+    INSTITUCIÓN: {{ receta.consulta.medico.institucion_cedula|default:"—" }}<br>
+    DIRECCIÓN: {{ receta.consulta.medico.consultorio.ubicacion|default:"—" }}
   </footer>
 </div>


### PR DESCRIPTION
## Summary
- shrink prescription layout to ensure single A5 page
- ensure missing doctor data falls back to safe defaults
- expose `fecha_validez` in the preview context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f2e354d08324847d882481a364d7