### PR TITLE
Add Rx style prescription view and template

### DIFF
--- a/consultorio_API/urls.py
+++ b/consultorio_API/urls.py
@@ -15,7 +15,7 @@ from .views_consultas import (
 from django.contrib.auth.views import LogoutView
 from .views import CitaCreateView, Receta
 from consultorio_API import views, viewscitas
-from consultorio_API.views_recetas import RecetaPreviewView
+from consultorio_API.views_recetas import RecetaPreviewView, RxRecetaView
 
 urlpatterns = [
       # LOGIN Y LOGOUT
@@ -107,6 +107,7 @@ urlpatterns = [
     # PDF y previsualización de recetas
     path('recetas/<int:receta_id>/pdf/', views.receta_pdf_view, name='receta_pdf'),
     path('recetas/<int:pk>/preview/', RecetaPreviewView.as_view(), name='receta_preview'),
+    path('recetas/<int:pk>/rx/', RxRecetaView.as_view(), name='receta_rx'),
     path('citas/exportar-csv/', viewscitas.exportar_citas_csv, name='exportar_citas_csv'),  # CAMBIAR
     
     

--- a/consultorio_API/views_recetas.py
+++ b/consultorio_API/views_recetas.py
@@ -29,3 +29,25 @@ class RecetaPreviewView(LoginRequiredMixin, DetailView):
         if not request.user.has_perm("consultorio.view_receta"):
             return HttpResponseForbidden()
         return super().dispatch(request, *args, **kwargs)
+
+
+class RxRecetaView(LoginRequiredMixin, DetailView):
+    """Receta con estilo tipo Rx para impresión simplificada."""
+
+    model = Receta
+    template_name = "PAGES/recetas/rx_receta.html"
+    context_object_name = "receta"
+    pk_url_kwarg = "pk"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["medico"] = self.object.consulta.medico
+        ctx["paciente"] = self.object.consulta.paciente
+        ctx["consultorio"] = self.object.consulta.medico.consultorio
+        return ctx
+
+    def dispatch(self, request, *args, **kwargs):
+        receta = self.get_object()
+        if not request.user.has_perm("consultorio.view_receta"):
+            return HttpResponseForbidden()
+        return super().dispatch(request, *args, **kwargs)

--- a/static/css/rx_receta.css
+++ b/static/css/rx_receta.css
@@ -1,0 +1,20 @@
+@page { size:A5 portrait; margin:12mm; }
+body  { margin:0; font:10.5pt/1.35 "Helvetica",sans-serif; }
+
+.A5       { width:126mm; margin:0 auto; }
+header    { text-align:center; margin-bottom:4mm; }
+header h3 { margin:0 0 1mm; font-size:12pt; }
+header p  { margin:0.5mm 0; }
+.folio    { position:absolute; right:12mm; top:12mm; font-size:9pt; }
+
+.paciente{ border:1px solid #000; padding:2mm; margin-bottom:3mm; }
+.paciente .mini{ font-size:9pt; }
+
+.cuerpo  h4 { margin:2mm 0 1mm; font-weight:700; }
+.meds    { margin-left:4mm; }
+.meds li { margin-bottom:1.5mm; }
+
+.obs     { border:1px dotted #555; height:22mm; padding:2mm; }
+
+footer   { text-align:center; margin-top:6mm; font-size:9pt; }
+.firma   { margin-top:1mm; }

--- a/templates/PAGES/consultas/consulta_card.html
+++ b/templates/PAGES/consultas/consulta_card.html
@@ -174,6 +174,12 @@
                     <i class="bi bi-eye me-2"></i>Ver Receta
                   </a>
                 </li>
+                <li>
+                  <a class="dropdown-item btn-preview-receta" href="#"
+                     data-preview-url="{% url 'receta_rx' consulta.receta.pk %}">
+                    <i class="bi bi-eye me-2"></i>Ver Receta estilo Rx
+                  </a>
+                </li>
               {% else %}
                 <li>
                   <a class="dropdown-item" href="{% url 'receta_nueva' consulta.pk %}">

--- a/templates/PAGES/consultas/detalle.html
+++ b/templates/PAGES/consultas/detalle.html
@@ -226,9 +226,13 @@
               Receta emitida el {{ receta.fecha_emision|date:"d/m/Y" }}
             </p>
             {% if receta.medicamentos.exists %}
-              <a href="#" class="btn btn-sm btn-outline-primary btn-preview-receta w-100 mb-3"
+              <a href="#" class="btn btn-sm btn-outline-primary btn-preview-receta w-100 mb-2"
                  data-preview-url="{% url 'receta_preview' receta.pk %}">
                 <i class="bi bi-eye me-1"></i>Ver Receta
+              </a>
+              <a href="#" class="btn btn-sm btn-outline-primary btn-preview-receta w-100 mb-3"
+                 data-preview-url="{% url 'receta_rx' receta.pk %}">
+                <i class="bi bi-eye me-1"></i>Ver Receta estilo Rx
               </a>
             {% endif %}
 

--- a/templates/PAGES/pacientes/detalle.html
+++ b/templates/PAGES/pacientes/detalle.html
@@ -436,6 +436,12 @@
                                   <i class="bi bi-eye me-2 text-success"></i>Ver Receta
                                 </a>
                               </li>
+                              <li>
+                                <a class="dropdown-item btn-preview-receta" href="#"
+                                   data-preview-url="{% url 'receta_rx' c.receta.pk %}">
+                                  <i class="bi bi-eye me-2 text-success"></i>Ver Receta estilo Rx
+                                </a>
+                              </li>
                             {% else %}
                               <li>
                                 <a class="dropdown-item" href="{% url 'receta_nueva' c.pk %}?next={{ request.path }}">

--- a/templates/PAGES/recetas/rx_receta.html
+++ b/templates/PAGES/recetas/rx_receta.html
@@ -1,0 +1,51 @@
+{% load static %}
+<link rel="stylesheet" href="{% static 'css/rx_receta.css' %}">
+
+<div id="receta-print-area" class="rx A5">
+  <!-- CABECERA -->
+  <header>
+      <h3>DR. {{ medico.get_full_name }}</h3>
+      <p>{{ medico.institucion_cedula }} — Cédula Prof. {{ medico.cedula_profesional }}</p>
+      <p>{{ consultorio.ubicacion }}</p>
+      <p>Teléfono: {{ consultorio.telefono }}</p>
+      <div class="folio">
+        <span>Folio:</span> <strong>{{ receta.pk|stringformat:"05d" }}</strong><br>
+        <span>Fecha:</span> <strong>{{ receta.fecha_emision|date:"d/m/Y" }}</strong>
+      </div>
+  </header>
+
+  <!-- DATOS PACIENTE -->
+  <section class="paciente">
+      <div><strong>Nombre del paciente:</strong> {{ paciente }}</div>
+      <div class="mini">
+          <span>No. Expediente: {{ paciente.expediente|default:"—" }}</span> ·
+          <span>Edad: {{ paciente.edad }} años</span> ·
+          <span>Fecha nacimiento: {{ paciente.fecha_nacimiento|date:"d/m/Y" }}</span>
+      </div>
+  </section>
+
+  <!-- RECETARIO -->
+  <section class="cuerpo">
+      <h4>Rx</h4>
+      <ol class="meds">
+          {% for m in receta.medicamentos.all %}
+            <li>
+              {{ m.nombre|upper }} – {{ m.dosis }}.<br>
+              {{ m.frecuencia }}, Duración: {{ m.duracion }},
+              Vía: {{ m.via_administracion|default:"Oral" }}.
+            </li>
+          {% empty %}
+            <li>No hay medicamentos.</li>
+          {% endfor %}
+      </ol>
+
+      <h4>Observaciones</h4>
+      <p class="obs">{{ receta.notas|default:"__________" }}</p>
+  </section>
+
+  <!-- FIRMA -->
+  <footer>
+      <p>________________________________________</p>
+      <p class="firma">Dr. {{ medico.get_full_name }}</p>
+  </footer>
+</div>


### PR DESCRIPTION
## Summary
- implement new RxRecetaView and URL
- add rx_receta.html template and CSS
- link Rx style recipe from patient and consultation pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688303a22c24832499eaee4a909d416f