### PR TITLE
Implement home redirect

### DIFF
--- a/consultorio_API/urls.py
+++ b/consultorio_API/urls.py
@@ -18,6 +18,7 @@ from consultorio_API import views, viewscitas
 from consultorio_API.views_recetas import RecetaPreviewView, RxRecetaView, RecetaA5View
 
 urlpatterns = [
+    path('', views.home_redirect, name='home'),
       # LOGIN Y LOGOUT
     path('login/', views.CustomLoginView.as_view(), name='login'),
     path('logout/', views.logout_view, name='logout'),

--- a/consultorio_API/views.py
+++ b/consultorio_API/views.py
@@ -92,6 +92,19 @@ def logout_view(request):
         return redirect(next_url)
     return redirect_next(request, 'login')
 
+
+def home_redirect(request):
+    """Redirige la raíz `/` según el rol del usuario."""
+    if request.user.is_authenticated:
+        rol = getattr(request.user, 'rol', '')
+        if rol == 'medico':
+            return redirect('dashboard_medico')
+        elif rol == 'asistente':
+            return redirect('citas_lista')
+        else:
+            return redirect('dashboard_admin')
+    return redirect_next(request, 'login')
+
 # ═══════════════════════════════════════════════════════════════
 # 🏠 DASHBOARDS CORREGIDOS
 # ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add `home_redirect` to route '/' according to user role
- register root path first in consultorio_API URL patterns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883501f75708324869e2d746535f54b