### PR TITLE
Implement patient pagination fix and actions

### DIFF
--- a/consultorio_API/apps.py
+++ b/consultorio_API/apps.py
@@ -2,22 +2,9 @@ from django.apps import AppConfig
 
 
 class ConsultorioApiConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'consultorio_API'
-
-from django.apps import AppConfig
-class ConsultorioApiConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "consultorio_API"
 
     def ready(self):
-        from . import signals   # noqa
-        
-        
-class ConsultorioApiConfig(AppConfig):
-    default_auto_field = "django.db.models.BigAutoField"
-    name = "consultorio_API"
-
-    def ready(self):
-        # Importa las señales al arrancar
+        """Import application signals at startup."""
         import consultorio_API.signals  # noqa: F401

--- a/consultorio_API/templatetags/url_replace.py
+++ b/consultorio_API/templatetags/url_replace.py
@@ -1,0 +1,9 @@
+from django import template
+
+register = template.Library()
+
+@register.simple_tag
+def url_replace(request, field, value):
+    query = request.GET.copy()
+    query[field] = value
+    return query.urlencode()

--- a/templates/PAGES/pacientes/detalle.html
+++ b/templates/PAGES/pacientes/detalle.html
@@ -422,21 +422,9 @@
                         <span class="badge bg-info">{{ c.get_tipo_display }}</span>
                       </td>
                       <td>
-                        {% if c.estado == "finalizada" %}
-                          <span class="badge bg-success">
-                            <i class="bi bi-check-circle me-1"></i>{{ c.get_estado_display }}
-                          </span>
-                        {% elif c.estado == "cancelada" %}
-                          <span class="badge bg-danger">
-                            <i class="bi bi-x-circle me-1"></i>{{ c.get_estado_display }}
-                          </span>
-                        {% elif c.estado == "en_progreso" %}
-                          <span class="badge bg-warning">
-                            <i class="bi bi-clock me-1"></i>{{ c.get_estado_display }}
-                          </span>
-                        {% else %}
-                          <span class="badge bg-secondary">{{ c.get_estado_display }}</span>
-                        {% endif %}
+                        <a href="{% url 'consulta_detalle' c.pk %}">
+                          {{ c.get_estado_display }}
+                        </a>
                       </td>
                       <td>
                         {% if c.medico %}
@@ -476,61 +464,34 @@
                           </span>
                         {% endif %}
                       </td>
-                      <td>
-                        <div class="btn-group" role="group">
-                          <button type="button" class="btn btn-sm btn-outline-secondary dropdown-toggle" 
-                                  data-bs-toggle="dropdown">
-                            <i class="bi bi-three-dots"></i>
+                      <td class="text-end">
+                        <div class="dropdown">
+                          <button class="btn btn-sm btn-outline-secondary" data-bs-toggle="dropdown">
+                            ⋮
                           </button>
                           <ul class="dropdown-menu dropdown-menu-end">
-                            {% if c.estado != "finalizada" %}
+                            <li>
+                              <a class="dropdown-item" href="{% url 'consulta_detalle' c.pk %}">
+                                Ver detalle
+                              </a>
+                            </li>
+
+                            {% if c.estado in 'espera,en_progreso' %}
                               <li>
-                                <a class="dropdown-item" href="{% url 'consultas_atencion' c.pk %}?next={{ request.path }}">
-                                  <i class="bi bi-heart-pulse me-2 text-info"></i>Atender
-                                </a>
-                              </li>
-                            {% endif %}
-                            
-                            {% if not c.signos_vitales %}
-                              <li>
-                                <a class="dropdown-item" href="{% url 'consultas_precheck' c.pk %}?next={{ request.path }}">
-                                  <i class="bi bi-thermometer-half me-2 text-warning"></i>Signos Vitales
-                                </a>
-                              </li>
-                            {% endif %}
-                            
-                            {% if c.receta %}
-                              <li>
-                                <a class="dropdown-item btn-preview-receta" href="#"
-                                   data-preview-url="{% url 'receta_a5' c.receta.pk %}">
-                                  <i class="bi bi-eye me-2 text-success"></i>Ver Receta
-                                </a>
-                              </li>
-                            {% else %}
-                              <li>
-                                <a class="dropdown-item" href="{% url 'receta_nueva' c.pk %}?next={{ request.path }}">
-                                  <i class="bi bi-file-earmark-plus me-2 text-primary"></i>Emitir Receta
-                                </a>
-                              </li>
-                            {% endif %}
-                            
-                            {% if c.estado == "finalizada" %}
-                              <li><hr class="dropdown-divider"></li>
-                              <li>
-                                <a class="dropdown-item" href="{% url 'consulta_editar' c.pk %}?next={{ request.path }}">
-                                  <i class="bi bi-pencil-square me-2 text-warning"></i>Editar
-                                </a>
-                              </li>
-                            {% endif %}
-                            
-                            {% if c.estado == "finalizada" or c.estado == "cancelada" %}
-                              <li>
-                                <form method="post" action="{% url 'consulta_eliminar' c.pk %}" onsubmit="return confirm('¿Estás seguro de eliminar?');">
+                                <form action="{% url 'consulta_cancelar' c.pk %}" method="post"
+                                      onsubmit="return confirm('¿Cancelar consulta?');">
                                   {% csrf_token %}
-                                  <input type="hidden" name="next" value="{{ request.path }}">
-                                  <button class="dropdown-item text-danger" type="submit">
-                                    <i class="bi bi-trash3 me-2"></i>Eliminar
-                                  </button>
+                                  <button class="dropdown-item text-warning">Cancelar</button>
+                                </form>
+                              </li>
+                            {% endif %}
+
+                            {% if c.estado != 'cancelada' %}
+                              <li>
+                                <form action="{% url 'consulta_eliminar' c.pk %}" method="post"
+                                      onsubmit="return confirm('Esta acción es irreversible. ¿Eliminar?');">
+                                  {% csrf_token %}
+                                  <button class="dropdown-item text-danger">Eliminar</button>
                                 </form>
                               </li>
                             {% endif %}

--- a/templates/PAGES/pacientes/lista.html
+++ b/templates/PAGES/pacientes/lista.html
@@ -136,33 +136,7 @@
 
   <!-- Paginación -->
   {% if is_paginated %}
-    <nav class="mt-4 d-flex justify-content-center">
-      <ul class="pagination">
-        {% if page_obj.has_previous %}
-          <li class="page-item"><a class="page-link" href="?page=1{{ request.GET.urlencode|safe|cut:'page=' }}">« Primero</a></li>
-          <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}{{ request.GET.urlencode|safe|cut:'page=' }}">‹ Anterior</a></li>
-        {% else %}
-          <li class="page-item disabled"><span class="page-link">«</span></li>
-          <li class="page-item disabled"><span class="page-link">‹</span></li>
-        {% endif %}
-
-        {% for i in page_obj.paginator.page_range %}
-          {% if page_obj.number == i %}
-            <li class="page-item active"><span class="page-link">{{ i }}</span></li>
-          {% elif i >= page_obj.number|add:"-2" and i <= page_obj.number|add:"2" %}
-            <li class="page-item"><a class="page-link" href="?page={{ i }}{{ request.GET.urlencode|safe|cut:'page=' }}">{{ i }}</a></li>
-          {% endif %}
-        {% endfor %}
-
-        {% if page_obj.has_next %}
-          <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}{{ request.GET.urlencode|safe|cut:'page=' }}">Siguiente ›</a></li>
-          <li class="page-item"><a class="page-link" href="?page={{ page_obj.paginator.num_pages }}{{ request.GET.urlencode|safe|cut:'page=' }}">Último »</a></li>
-        {% else %}
-          <li class="page-item disabled"><span class="page-link">›</span></li>
-          <li class="page-item disabled"><span class="page-link">»</span></li>
-        {% endif %}
-      </ul>
-    </nav>
+    {% include 'PAGES/partials/_paginacion.html' %}
   {% endif %}
 
 </div>

--- a/templates/PAGES/partials/_paginacion.html
+++ b/templates/PAGES/partials/_paginacion.html
@@ -1,0 +1,45 @@
+{% load url_replace %}
+
+{% if page_obj.paginator.num_pages > 1 %}
+<nav aria-label="Paginación">
+  <ul class="pagination justify-content-center">
+
+    {# « Primero » #}
+    <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}">
+      <a class="page-link" href="?{% url_replace request 'page' 1 %}">
+        « Primero
+      </a>
+    </li>
+
+    {# « Anterior » #}
+    <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}">
+      <a class="page-link" href="?{% url_replace request 'page' page_obj.previous_page_number %}">
+        ‹ Anterior
+      </a>
+    </li>
+
+    {# números #}
+    {% for n in page_obj.paginator.page_range %}
+      {% if n|add:'-2' <= page_obj.number <= n|add:'2' %}
+        <li class="page-item {% if n == page_obj.number %}active{% endif %}">
+          <a class="page-link" href="?{% url_replace request 'page' n %}">{{ n }}</a>
+        </li>
+      {% endif %}
+    {% endfor %}
+
+    {# « Siguiente » #}
+    <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}">
+      <a class="page-link" href="?{% url_replace request 'page' page_obj.next_page_number %}">
+        Siguiente ›
+      </a>
+    </li>
+
+    {# « Último » #}
+    <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}">
+      <a class="page-link" href="?{% url_replace request 'page' page_obj.paginator.num_pages %}">
+        Último »
+      </a>
+    </li>
+  </ul>
+</nav>
+{% endif %}


### PR DESCRIPTION
## Summary
- add `url_replace` template tag
- add generic pagination partial
- reuse pagination partial in patient list
- link consulta rows to detail and simplify action menu
- clean up app config and load custom template tag by full path
- fix template tag loading in pagination partial

## Testing
- `python manage.py check`
- `pytest -q` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_68835b15fad48324a916d8ad5a3a3b46