### PR TITLE
Fix date preselection for CitaCreateView

### DIFF
--- a/consultorio_API/forms.py
+++ b/consultorio_API/forms.py
@@ -438,7 +438,11 @@ class CitaForm(forms.ModelForm):
     # ---------- fecha / hora / duración ----------
     fecha = forms.DateField(
         label=_("Fecha"),
-        widget=forms.DateInput(attrs={"type": "date", "class": "form-control"}),
+        widget=forms.DateInput(
+            attrs={"type": "date", "class": "form-control"},
+            format="%Y-%m-%d",
+        ),
+        input_formats=["%Y-%m-%d"],
     )
     hora = forms.ChoiceField(
         label=_("Hora"),

--- a/consultorio_API/views.py
+++ b/consultorio_API/views.py
@@ -4285,12 +4285,21 @@ class CitaCreateView(NextRedirectMixin, CitaPermisoMixin, CreateView):
 
     def get_initial(self):
         initial = super().get_initial()
-        fecha_str = self.request.GET.get('fecha')
-        if fecha_str:
-            try:
-                initial['fecha'] = datetime.strptime(fecha_str, '%Y-%m-%d').date()
-            except ValueError:
-                pass
+        fecha_raw = self.request.GET.get("fecha")
+
+        if fecha_raw:
+            # Pasar la fecha tal como viene en la URL
+            initial["fecha"] = fecha_raw
+
+            # Si la URL incluye hora (YYYY-MM-DDTHH:mm)
+            if "T" in fecha_raw:
+                from django.utils.dateparse import parse_datetime
+
+                dt = parse_datetime(fecha_raw)
+                if dt:
+                    initial["fecha"] = dt.strftime("%Y-%m-%d")
+                    initial["hora"] = dt.strftime("%H:%M")
+
         return initial
 
     def get_form_kwargs(self):


### PR DESCRIPTION
## Summary
- ensure initial date and time parameters aren't reformatted in `CitaCreateView`
- specify ISO date format for `fecha` field widget in `CitaForm`

## Testing
- `pytest -q` *(fails: test_bloqueo_registrar_signos_cancelada)*

------
https://chatgpt.com/codex/tasks/task_e_6884224a83548324acf584be0150019d