### PR TITLE
Revamp dashboard layout

### DIFF
--- a/templates/PAGES/dashboard.html
+++ b/templates/PAGES/dashboard.html
@@ -8,127 +8,8 @@
 <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.10/index.global.min.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
-<style>
-  .dashboard-card {
-    transition: transform 0.2s ease-in-out;
-    border: none;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-  }
-  .dashboard-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 20px rgba(0,0,0,0.15);
-  }
-  .stat-card {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    border-radius: 15px;
-  }
-  .stat-card.success {
-    background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
-  }
-  .stat-card.warning {
-    background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-  }
-  .stat-card.info {
-    background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
-  }
-  .stat-card.danger {
-    background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-  }
-  #calendar .fc-event {
-    font-size: 0.8rem;
-    cursor: pointer;
-    border-radius: 4px;
-  }
-  #calendar .fc-event:hover {
-    opacity: 0.8;
-  }
-  .recent-activity {
-    max-height: 400px;
-    overflow-y: auto;
-  }
-  .activity-item {
-    border-left: 3px solid #007bff;
-    padding-left: 15px;
-    margin-bottom: 15px;
-  }
-  .activity-item.success {
-    border-left-color: #28a745;
-  }
-  .activity-item.warning {
-    border-left-color: #ffc107;
-  }
-  .activity-item.danger {
-    border-left-color: #dc3545;
-  }
-  .quick-action-btn {
-    height: 80px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    text-decoration: none;
-    color: inherit;
-    border-radius: 10px;
-    transition: all 0.3s ease;
-  }
-  .quick-action-btn:hover {
-    color: inherit;
-    transform: scale(1.05);
-  }
-  .cita-item {
-    cursor: pointer;
-    transition: background-color 0.2s;
-  }
-  .cita-item:hover {
-    background-color: #f8f9fa;
-  }
-  .alert-item {
-    border-left: 4px solid;
-    padding: 12px 16px;
-    margin-bottom: 10px;
-    border-radius: 0 8px 8px 0;
-  }
-  .alert-urgent {
-    border-left-color: #dc3545;
-    background-color: #f8d7da;
-  }
-  .alert-warning {
-    border-left-color: #ffc107;
-    background-color: #fff3cd;
-  }
-  .alert-info {
-    border-left-color: #0dcaf0;
-    background-color: #d1ecf1;
-  }
-  .metric-card {
-    text-align: center;
-    padding: 20px;
-    border-radius: 10px;
-    background: white;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-  }
-  .metric-value {
-    font-size: 2rem;
-    font-weight: bold;
-    color: #007bff;
-  }
-  .metric-label {
-    color: #6c757d;
-    font-size: 0.9rem;
-  }
-  .pulse {
-    animation: pulse 2s infinite;
-  }
-  @keyframes pulse {
-    0% { transform: scale(1); }
-    50% { transform: scale(1.05); }
-    100% { transform: scale(1); }
-  }
-</style>
-
 <div class="container-fluid py-4">
-  <!-- Header -->
+  <!-- Encabezado -->
   <div class="row mb-4">
     <div class="col">
       <h2 class="fw-bold text-primary mb-0">
@@ -136,153 +17,114 @@
       </h2>
       <p class="text-muted mb-0">Bienvenido de vuelta, {{ usuario.get_full_name }}</p>
     </div>
-    <div class="col-auto">
-      <div class="text-end">
-        <small class="text-muted">Última actualización:</small><br>
-        <span id="lastUpdate" class="fw-bold"></span>
-        <button class="btn btn-sm btn-outline-primary ms-2" onclick="actualizarDatos()">
-          <i class="bi bi-arrow-clockwise"></i>
-        </button>
-      </div>
+    <div class="col-auto text-end">
+      <small class="text-muted">Última actualización:</small><br>
+      <span id="lastUpdate" class="fw-bold"></span>
     </div>
   </div>
-
-
 
   <!-- Estadísticas principales -->
   <div class="row g-4 mb-4">
-    <div class="col-xl-3 col-md-6">
-      <div class="card dashboard-card stat-card">
+    <div class="col-md-3 col-sm-6">
+      <div class="card text-white bg-info shadow-sm">
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-center">
             <div>
-              <h6 class="card-title mb-1">Citas Hoy</h6>
+              <h6 class="mb-1">Citas Hoy</h6>
               <h3 class="mb-0" id="citasHoy">{{ stats.citas_hoy }}</h3>
-              <small class="opacity-75">{{ stats.citas_hoy_diff }} desde ayer</small>
             </div>
-            <div class="fs-1 opacity-75">
-              <i class="bi bi-calendar-check"></i>
-            </div>
-          </div>
-          <div class="progress mt-2" style="height: 4px;">
-            <div class="progress-bar bg-white" role="progressbar" style="width: 70%"></div>
+            <i class="bi bi-calendar-check fs-1"></i>
           </div>
         </div>
       </div>
     </div>
-    <div class="col-xl-3 col-md-6">
-      <div class="card dashboard-card stat-card success">
+    <div class="col-md-3 col-sm-6">
+      <div class="card text-white bg-success shadow-sm">
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-center">
             <div>
-              <h6 class="card-title mb-1">Consultas Finalizadas</h6>
+              <h6 class="mb-1">Consultas Finalizadas</h6>
               <h3 class="mb-0" id="consultasFinalizadas">{{ stats.consultas_finalizadas }}</h3>
-              <small class="opacity-75">Esta semana</small>
             </div>
-            <div class="fs-1 opacity-75">
-              <i class="bi bi-check-circle"></i>
-            </div>
-          </div>
-          <div class="progress mt-2" style="height: 4px;">
-            <div class="progress-bar bg-white" role="progressbar" style="width: 85%"></div>
+            <i class="bi bi-check-circle fs-1"></i>
           </div>
         </div>
       </div>
     </div>
-    <div class="col-xl-3 col-md-6">
-      <div class="card dashboard-card stat-card warning">
+    <div class="col-md-3 col-sm-6">
+      <div class="card text-dark bg-warning shadow-sm">
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-center">
             <div>
-              <h6 class="card-title mb-1">Pendientes</h6>
-              <h3 class="mb-0 pulse" id="consultasPendientes">{{ stats.consultas_pendientes }}</h3>
-              <small class="opacity-75">Requieren atención</small>
+              <h6 class="mb-1">Pendientes</h6>
+              <h3 class="mb-0" id="consultasPendientes">{{ stats.consultas_pendientes }}</h3>
             </div>
-            <div class="fs-1 opacity-75">
-              <i class="bi bi-hourglass-split"></i>
-            </div>
-          </div>
-          <div class="progress mt-2" style="height: 4px;">
-            <div class="progress-bar bg-white" role="progressbar" style="width: 45%"></div>
+            <i class="bi bi-hourglass-split fs-1"></i>
           </div>
         </div>
       </div>
     </div>
-    <div class="col-xl-3 col-md-6">
-      <div class="card dashboard-card stat-card info">
+    <div class="col-md-3 col-sm-6">
+      <div class="card text-white bg-secondary shadow-sm">
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-center">
             <div>
-              <h6 class="card-title mb-1">Pacientes Totales</h6>
+              <h6 class="mb-1">Pacientes Totales</h6>
               <h3 class="mb-0" id="pacientesTotales">{{ stats.pacientes_totales }}</h3>
-              <small class="opacity-75">{{ stats.pacientes_nuevos }} este mes</small>
             </div>
-            <div class="fs-1 opacity-75">
-              <i class="bi bi-people"></i>
-            </div>
-          </div>
-          <div class="progress mt-2" style="height: 4px;">
-            <div class="progress-bar bg-white" role="progressbar" style="width: 60%"></div>
+            <i class="bi bi-people fs-1"></i>
           </div>
         </div>
       </div>
     </div>
   </div>
-
 
   <!-- Acciones rápidas -->
   <div class="row mb-4">
     <div class="col">
-      <div class="card dashboard-card">
+      <div class="card shadow-sm">
         <div class="card-header bg-white">
-          <h5 class="card-title mb-0">
-            <i class="bi bi-lightning me-2"></i>Acciones Rápidas
-          </h5>
+          <h5 class="card-title mb-0"><i class="bi bi-lightning me-2"></i>Acciones Rápidas</h5>
         </div>
         <div class="card-body">
           <div class="row g-3">
             {% if usuario.rol == "admin" or usuario.rol == "medico" or usuario.rol == "asistente" %}
             <div class="col-md-2 col-6">
-              <a href="{% url 'citas_crear' %}?next={{ request.path }}" class="btn btn-outline-primary quick-action-btn w-100">
+              <a href="{% url 'citas_crear' %}?next={{ request.path }}" class="btn btn-outline-primary w-100">
                 <i class="bi bi-calendar-plus fs-3 mb-1"></i>
                 <small>Nueva Cita</small>
               </a>
             </div>
             {% endif %}
-            
             {% if usuario.rol == "admin" or usuario.rol == "medico" %}
             <div class="col-md-2 col-6">
-              <a href="{% url 'consultas_crear_sin_cita' %}?next={{ request.path }}" class="btn btn-outline-success quick-action-btn w-100">
+              <a href="{% url 'consultas_crear_sin_cita' %}?next={{ request.path }}" class="btn btn-outline-success w-100">
                 <i class="bi bi-clipboard-plus fs-3 mb-1"></i>
                 <small>Nueva Consulta</small>
               </a>
             </div>
             {% endif %}
-            
             <div class="col-md-2 col-6">
-              <a href="{% url 'pacientes_lista' %}" class="btn btn-outline-info quick-action-btn w-100">
+              <a href="{% url 'pacientes_lista' %}" class="btn btn-outline-info w-100">
                 <i class="bi bi-people fs-3 mb-1"></i>
                 <small>Ver Pacientes</small>
               </a>
             </div>
-            
             <div class="col-md-2 col-6">
-              <a href="{% url 'consultas_lista' %}" class="btn btn-outline-warning quick-action-btn w-100">
+              <a href="{% url 'consultas_lista' %}" class="btn btn-outline-warning w-100">
                 <i class="bi bi-list-check fs-3 mb-1"></i>
                 <small>Ver Consultas</small>
               </a>
             </div>
-            
             <div class="col-md-2 col-6">
-              <a href="{% url 'citas_lista' %}" class="btn btn-outline-secondary quick-action-btn w-100">
+              <a href="{% url 'citas_lista' %}" class="btn btn-outline-secondary w-100">
                 <i class="bi bi-calendar-event fs-3 mb-1"></i>
                 <small>Ver Citas</small>
               </a>
             </div>
-            
             {% if usuario.rol == "admin" %}
             <div class="col-md-2 col-6">
-              <a href="{% url 'horarios_lista' %}" class="btn btn-outline-dark quick-action-btn w-100">
+              <a href="{% url 'horarios_lista' %}" class="btn btn-outline-dark w-100">
                 <i class="bi bi-clock fs-3 mb-1"></i>
                 <small>Horarios</small>
               </a>
@@ -297,352 +139,92 @@
   <div class="row g-4">
     <!-- Calendario -->
     <div class="col-lg-8">
-      <div class="card dashboard-card border-0">
-        <div class="card-header bg-light fw-semibold d-flex justify-content-between align-items-center">
-          <div>
-            <i class="bi bi-calendar-event me-2"></i>Calendario de Citas
-          </div>
-          <div class="btn-group btn-group-sm">
-            <button class="btn btn-outline-primary" onclick="calendar.changeView('dayGridMonth')">Mes</button>
-            <button class="btn btn-outline-primary" onclick="calendar.changeView('timeGridWeek')">Semana</button>
-            <button class="btn btn-outline-primary" onclick="calendar.changeView('timeGridDay')">Día</button>
-            <button class="btn btn-outline-success" onclick="calendar.today()">Hoy</button>
-            <button class="btn btn-outline-info" onclick="exportarCalendario()">
-              <i class="bi bi-download"></i>
-            </button>
-          </div>
+      <div class="card shadow-sm">
+        <div class="card-header bg-light fw-semibold">
+          <i class="bi bi-calendar-event me-2"></i>Calendario de Citas
         </div>
-        <div class="card-body">
+        <div class="card-body p-0">
           <div id="calendar"></div>
         </div>
       </div>
     </div>
 
-    <!-- Panel lateral -->
+    <!-- Próximas Citas -->
     <div class="col-lg-4">
-      <!-- Próximas citas -->
-      <div class="card dashboard-card border-0 mb-4">
-        <div class="card-header bg-light fw-semibold d-flex justify-content-between align-items-center">
-          <div>
-            <i class="bi bi-clock me-2"></i>Próximas Citas
-          </div>
-          <button class="btn btn-sm btn-outline-primary" onclick="actualizarProximasCitas()">
-            <i class="bi bi-arrow-clockwise"></i>
-          </button>
+      <div class="card shadow-sm h-100">
+        <div class="card-header bg-light fw-semibold">
+          <i class="bi bi-clock me-2"></i>Próximas Citas
         </div>
-        <div class="card-body" id="proximasCitasContainer">
+        <div class="card-body">
           {% if proximas_citas %}
             {% for cita in proximas_citas %}
-            <div class="d-flex align-items-center mb-3 p-2 border rounded cita-item" onclick="verDetalleCita('{{ cita.id }}')">
-              <div class="me-3">
-                <div class="bg-primary text-white rounded-circle d-flex align-items-center justify-content-center" style="width: 40px; height: 40px;">
-                  <i class="bi bi-person"></i>
-                </div>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-1">{{ cita.paciente.nombre_completo }}</h6>
-                <small class="text-muted">
-                  {{ cita.fecha_hora|date:"d/m/Y" }} - {{ cita.fecha_hora|time:"H:i" }}
-                </small>
-                <br>
-                <small class="text-primary">{{ cita.motivo|default:"Consulta general" }}</small>
-              </div>
-              <div>
+            <div class="card card-sm mb-3 shadow-sm">
+              <div class="card-body p-2">
+                <strong>{{ cita.paciente.nombre_completo }}</strong><br>
+                <small class="text-muted">{{ cita.fecha_hora|date:"d/m/Y" }} - {{ cita.fecha_hora|time:"H:i" }}</small><br>
                 <span class="badge bg-{% if cita.estado == 'programada' %}primary{% elif cita.estado == 'confirmada' %}success{% elif cita.estado == 'en_espera' %}warning{% elif cita.estado == 'completada' %}success{% else %}danger{% endif %}">
                   {{ cita.get_estado_display }}
                 </span>
+                <a href="{% url 'detalle_cita' cita.id %}" class="btn btn-outline-primary btn-sm w-100 mt-2">
+                  <i class="bi bi-eye"></i> Ver Detalle
+                </a>
               </div>
             </div>
             {% endfor %}
           {% else %}
-            <p class="text-muted">No hay citas próximas</p>
+            <p class="text-muted mb-0">No hay citas próximas</p>
           {% endif %}
-        </div>
-      </div>
-
-      <!-- Actividad reciente -->
-      <div class="card dashboard-card border-0">
-        <div class="card-header bg-light fw-semibold d-flex justify-content-between align-items-center">
-          <div>
-            <i class="bi bi-activity me-2"></i>Actividad Reciente
-          </div>
-          <button class="btn btn-sm btn-outline-primary" onclick="actualizarActividad()">
-            <i class="bi bi-arrow-clockwise"></i>
-          </button>
-        </div>
-        <div class="card-body recent-activity" id="actividadRecienteContainer">
-          {% if actividad_reciente %}
-            {% for actividad in actividad_reciente %}
-            <div class="activity-item {% if actividad.tipo == 'consulta_finalizada' %}success{% elif actividad.tipo == 'cita_proxima' %}warning{% elif actividad.tipo == 'nuevo_paciente' %}info{% else %}danger{% endif %}">
-              <div class="d-flex align-items-start">
-                <div class="me-3">
-                  <i class="bi bi-{% if actividad.tipo == 'consulta_finalizada' %}check-circle{% elif actividad.tipo == 'cita_proxima' %}clock{% elif actividad.tipo == 'nuevo_paciente' %}person-plus{% else %}exclamation-triangle{% endif %} fs-5"></i>
-                </div>
-                <div class="flex-grow-1">
-                  <h6 class="mb-1">{{ actividad.titulo }}</h6>
-                  <p class="mb-1 text-muted">{{ actividad.descripcion }}</p>
-                  <small class="text-muted">{{ actividad.fecha|timesince }} ago</small>
-                </div>
-              </div>
-            </div>
-            {% endfor %}
-          {% else %}
-            <p class="text-muted">No hay actividad reciente</p>
-          {% endif %}
-        </div>
-      </div>
-    </div>
-  </div>
-
-
-  <!-- Widgets adicionales -->
-  <div class="row g-4 mt-2">
-    <div class="col-lg-12">
-      <div class="card dashboard-card border-0">
-        <div class="card-header bg-light fw-semibold">
-          <i class="bi bi-people-fill me-2"></i>Médicos del Consultorio
-        </div>
-        <div class="card-body" id="medicosWidget">
-          <!-- Se cargará dinámicamente -->
         </div>
       </div>
     </div>
   </div>
 </div>
 
-<!-- Modal para detalles de cita -->
-<div class="modal fade" id="citaModal" tabindex="-1">
-  <div class="modal-dialog modal-lg">
+<!-- Modal del calendario -->
+<div class="modal fade" id="calendarModal" tabindex="-1">
+  <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">
-          <i class="bi bi-calendar-event me-2"></i>Detalles de la Cita
-        </h5>
+        <h5 class="modal-title"><i class="bi bi-calendar-event me-2"></i>Detalle rápido de la cita</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
-      <div class="modal-body" id="citaModalBody">
-        <!-- Contenido dinámico -->
-      </div>
+      <div class="modal-body" id="calendarModalBody"></div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
-        <button type="button" class="btn btn-primary" id="btnAtender" style="display: none;">Atender Consulta</button>
-        <button type="button" class="btn btn-info" id="btnEditar" style="display: none;">Editar Cita</button>
-        <button type="button" class="btn btn-success" id="btnSignos" style="display: none;">Registrar Signos</button>
+        <a id="detalleCitaBtn" href="#" class="btn btn-primary w-100 mt-3">
+          <i class="bi bi-info-circle"></i> Ver Detalle de la Cita
+        </a>
       </div>
     </div>
   </div>
 </div>
+{% endblock %}
 
+{% block extra_js %}
 <script>
-document.addEventListener('DOMContentLoaded', function () {
-  let calendar;
-
-  /* ---------- CALENDARIO ---------- */
-  const calendarEl = document.getElementById('calendar');
-  calendar = new FullCalendar.Calendar(calendarEl, {
-    initialView: 'dayGridMonth',
-    locale: 'es',
-    height: 650,
-    headerToolbar: {
-      left: 'prev,next today',
-      center: 'title',
-      right: 'dayGridMonth,timeGridWeek,timeGridDay'
-    },
-    eventTimeFormat: { hour: '2-digit', minute: '2-digit', meridiem: false },
-    events: {{ eventos_json|safe }},
-    eventClick: function(info) {
-      mostrarDetalleCita(info.event.id);
-    },
-    eventMouseEnter: function(info) {
-      info.el.style.cursor = 'pointer';
-      info.el.title = info.event.title + ' - ' + (info.event.extendedProps.motivo || 'Consulta general');
-    },
-    dateClick: function(info) {
-      // Redirigir a crear cita en esa fecha
-      window.location.href = `{% url 'citas_crear' %}?fecha=${info.dateStr}&next={{ request.path }}`;
-    }
-  });
-  calendar.render();
-
-
-  // Inicializar datos
-  cargarMetricasAdicionales();
-  cargarMedicosWidget();
-  
-  // Actualizar cada 5 minutos
-  setInterval(actualizarDatos, 300000);
-  
-  // Actualizar última actualización
-  updateLastUpdate();
-  setInterval(updateLastUpdate, 60000);
-});
-
-/* ---------- FUNCIONES DE ACTUALIZACIÓN ---------- */
-function actualizarDatos() {
-  fetch('{% url "ajax_dashboard_stats" %}')
-    .then(response => response.json())
-    .then(data => {
-      if (data.stats) {
-        document.getElementById('citasHoy').textContent = data.stats.citas_hoy || 0;
-        document.getElementById('consultasFinalizadas').textContent = data.stats.consultas_finalizadas || 0;
-        document.getElementById('consultasPendientes').textContent = data.stats.consultas_pendientes || 0;
-        document.getElementById('pacientesTotales').textContent = data.stats.pacientes_totales || 0;
-      }
-      cargarMetricasAdicionales();
-    })
-    .catch(error => console.error('Error actualizando datos:', error));
-}
-
-function cargarMetricasAdicionales() {
-  // Simular carga de métricas adicionales
-  document.getElementById('tiempoPromedioAtencion').textContent = '25min';
-  document.getElementById('satisfaccionPromedio').textContent = '4.8★';
-  document.getElementById('medicosActivos').textContent = '8';
-  document.getElementById('citasCanceladas').textContent = '2';
-  document.getElementById('ingresosDia').textContent = '$1,250';
-  document.getElementById('eficienciaConsultorio').textContent = '92%';
-}
-
-function cargarMedicosWidget() {
-  const medicos = [
-    { nombre: 'Dr. García', especialidad: 'Medicina General', estado: 'activo', consultas: 12 },
-    { nombre: 'Dra. López', especialidad: 'Pediatría', estado: 'ocupado', consultas: 8 },
-    { nombre: 'Dr. Martínez', especialidad: 'Cardiología', estado: 'disponible', consultas: 15 }
-  ];
-
-  const medicosWidget = document.getElementById('medicosWidget');
-  medicosWidget.innerHTML = medicos.map(medico => `
-    <div class="d-flex align-items-center mb-3 p-2 border rounded">
-      <div class="me-3">
-        <div class="position-relative">
-          <div class="bg-primary text-white rounded-circle d-flex align-items-center justify-content-center" style="width: 40px; height: 40px;">
-            <i class="bi bi-person-fill"></i>
-          </div>
-          <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-${medico.estado === 'activo' ? 'success' : medico.estado === 'ocupado' ? 'warning' : 'secondary'}">
-            <span class="visually-hidden">${medico.estado}</span>
-          </span>
-        </div>
-      </div>
-      <div class="flex-grow-1">
-        <h6 class="mb-1">${medico.nombre}</h6>
-        <small class="text-muted">${medico.especialidad}</small>
-        <br>
-        <small class="text-primary">${medico.consultas} consultas hoy</small>
-      </div>
-    </div>
-  `).join('');
-}
-
-/* ---------- FUNCIONES DE INTERACCIÓN ---------- */
-
-function exportarCalendario() {
-  // Implementar exportación del calendario
-  alert('Funcionalidad de exportación del calendario');
-}
-
-function actualizarProximasCitas() {
-  // Implementar actualización de próximas citas
-  console.log('Actualizando próximas citas...');
-}
-
-function actualizarActividad() {
-  // Implementar actualización de actividad reciente
-  console.log('Actualizando actividad reciente...');
-}
-
 function updateLastUpdate() {
   document.getElementById('lastUpdate').textContent = new Date().toLocaleString('es-ES');
 }
 
-function mostrarDetalleCita(citaId) {
-  // Hacer petición AJAX para obtener detalles de la cita
-  fetch(`/ajax/cita-detalle/${citaId}/`)
-    .then(response => response.json())
-    .then(data => {
-      if (data.success) {
-        const cita = data.cita;
-        const modalBody = document.getElementById('citaModalBody');
-        
-        modalBody.innerHTML = `
-          <div class="row">
-            <div class="col-md-6">
-              <h6 class="text-primary">Información del Paciente</h6>
-              <p><strong>Nombre:</strong> ${cita.paciente.nombre}</p>
-              <p><strong>Edad:</strong> ${cita.paciente.edad} años</p>
-              <p><strong>Teléfono:</strong> ${cita.paciente.telefono}</p>
-              <p><strong>Correo:</strong> ${cita.paciente.correo}</p>
-            </div>
-            <div class="col-md-6">
-              <h6 class="text-primary">Información de la Cita</h6>
-              <p><strong>Fecha:</strong> ${cita.fecha}</p>
-              <p><strong>Hora:</strong> ${cita.hora}</p>
-              <p><strong>Médico:</strong> ${cita.medico}</p>
-              <p><strong>Consultorio:</strong> ${cita.consultorio}</p>
-              <p><strong>Duración:</strong> ${cita.duracion} minutos</p>
-            </div>
-          </div>
-          <div class="row mt-3">
-            <div class="col-12">
-              <h6 class="text-primary">Motivo de la Consulta</h6>
-              <p>${cita.motivo || 'No especificado'}</p>
-              ${cita.notas ? `<h6 class="text-primary">Notas</h6><p>${cita.notas}</p>` : ''}
-              <div class="alert alert-info">
-                <strong>Estado:</strong> 
-                <span class="badge bg-${getEstadoColor(cita.estado)}">${cita.estado_display}</span>
-              </div>
-              ${cita.consulta ? `
-                <div class="alert alert-success">
-                  <strong>Consulta asociada:</strong> 
-                  <a href="{% url 'consulta_detalle' 0 %}".replace('0', cita.consulta.id) class="btn btn-sm btn-outline-primary ms-2">Ver consulta</a>
-                </div>
-              ` : ''}
-            </div>
-          </div>
-        `;
+document.addEventListener('DOMContentLoaded', function() {
+  updateLastUpdate();
+  setInterval(updateLastUpdate, 60000);
 
-        // Configurar botones según el estado y permisos
-        const btnAtender = document.getElementById('btnAtender');
-        const btnEditar = document.getElementById('btnEditar');
-        const btnSignos = document.getElementById('btnSignos');
-
-        // Mostrar/ocultar botones según el contexto
-        if (cita.consulta && cita.estado !== 'completada' && cita.estado !== 'cancelada') {
-          btnAtender.style.display = 'inline-block';
-          btnAtender.onclick = () => window.location.href = `{% url 'consultas_atencion' 0 %}`.replace('0', cita.consulta.id);
-        } else {
-          btnAtender.style.display = 'none';
-        }
-
-        if (cita.puede_editar) {
-          btnEditar.style.display = 'inline-block';
-          btnEditar.onclick = () => window.location.href = `{% url 'citas_editar' '00000000-0000-0000-0000-000000000000' %}`.replace('00000000-0000-0000-0000-000000000000', citaId);
-        } else {
-          btnEditar.style.display = 'none';
-        }
-
-        if (cita.consulta && !cita.tiene_signos) {
-          btnSignos.style.display = 'inline-block';
-          btnSignos.onclick = () => window.location.href = `{% url 'consultas_precheck' 0 %}`.replace('0', cita.consulta.id);
-        } else {
-          btnSignos.style.display = 'none';
-        }
-
-        // Mostrar modal
-        const modal = new bootstrap.Modal(document.getElementById('citaModal'));
-        modal.show();
-      } else {
-        alert('Error al cargar los detalles de la cita');
-      }
-    })
-    .catch(error => {
-      console.error('Error:', error);
-      alert('Error al cargar los detalles de la cita');
-    });
-}
-
-function verDetalleCita(citaId) {
-  window.location.href = `{% url 'citas_detalle' '00000000-0000-0000-0000-000000000000' %}`.replace('00000000-0000-0000-0000-000000000000', citaId);
-}
+  const calendarEl = document.getElementById('calendar');
+  const calendar = new FullCalendar.Calendar(calendarEl, {
+    initialView: 'dayGridMonth',
+    locale: 'es',
+    height: 600,
+    events: {{ eventos_json|safe }},
+    eventClick: function(info) {
+      document.getElementById('calendarModalBody').innerHTML = '<strong>' + info.event.title + '</strong><br>' +
+        '<small>' + (info.event.extendedProps.motivo || '') + '</small>'; 
+      document.getElementById('detalleCitaBtn').setAttribute('href', '/citas/' + info.event.id + '/detalle/');
+      const modal = new bootstrap.Modal(document.getElementById('calendarModal'));
+      modal.show();
+    }
+  });
+  calendar.render();
+});
 
 function getEstadoColor(estado) {
   const colores = {
@@ -655,6 +237,5 @@ function getEstadoColor(estado) {
   };
   return colores[estado] || 'secondary';
 }
-
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- simplify dashboard HTML
- remove unused sections and graphs
- add detail links in upcoming appointments and calendar modal

## Testing
- `pytest -q` *(fails: PytestUnknownMarkWarning and 8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688434d375f08324bcafea16461f8a7a