### PR TITLE
Enhance patient detail with appointment history

### DIFF
--- a/consultorio_API/forms.py
+++ b/consultorio_API/forms.py
@@ -469,10 +469,18 @@ class CitaForm(forms.ModelForm):
         )
 
     # ───────────────────────── constructor ──────────────────────────
-    def __init__(self, *args: Any, user: Usuario | None = None, **kwargs: Any):
+    def __init__(self, *args: Any, user: Usuario | None = None, paciente_fijo: Paciente | None = None, **kwargs: Any):
         self._user = user
+        self.paciente_fijo = paciente_fijo
         kwargs.pop("user", None)
+        kwargs.pop("paciente_fijo", None)
         super().__init__(*args, **kwargs)
+
+        if paciente_fijo:
+            self.fields["paciente"].initial = paciente_fijo
+            self.fields["paciente"].queryset = Paciente.objects.filter(pk=paciente_fijo.pk)
+            self.fields["paciente"].widget = forms.HiddenInput()
+            self.paciente_nombre = paciente_fijo.nombre_completo
 
         # edición
         if self.instance.pk and self.instance.consultorio_id and self.instance.fecha_hora:

--- a/consultorio_API/urls.py
+++ b/consultorio_API/urls.py
@@ -119,9 +119,10 @@ urlpatterns = [
     
     
     
-    path("citas/", CitaListView.as_view(), name="citas_lista"), 
-    path('ajax/horarios/', obtener_horarios_disponibles, name='ajax_horarios_disponibles'), 
-    path("citas/crear/", CitaCreateView.as_view(), name="citas_crear"), 
+    path("citas/", CitaListView.as_view(), name="citas_lista"),
+    path('ajax/horarios/', obtener_horarios_disponibles, name='ajax_horarios_disponibles'),
+    path("citas/crear/", CitaCreateView.as_view(), name="citas_crear"),
+    path('citas/crear/paciente/<int:paciente_id>/', views.crear_cita_para_paciente, name='crear_cita_paciente'),
   
    
    

--- a/templates/PAGES/citas/crear.html
+++ b/templates/PAGES/citas/crear.html
@@ -132,7 +132,12 @@
                                         <label for="{{ form.paciente.id_for_label }}" class="form-label">
                                             {{ form.paciente.label }} <span class="required-field">*</span>
                                         </label>
-                                        {{ form.paciente }}
+                                        {% if form.paciente.field.widget.input_type == 'hidden' %}
+                                            <input type="text" class="form-control" value="{{ form.paciente_nombre }}" readonly>
+                                            {{ form.paciente }}
+                                        {% else %}
+                                            {{ form.paciente }}
+                                        {% endif %}
                                         {% if form.paciente.errors %}
                                             <div class="invalid-feedback d-block">
                                                 {{ form.paciente.errors.0 }}

--- a/templates/PAGES/pacientes/detalle.html
+++ b/templates/PAGES/pacientes/detalle.html
@@ -117,6 +117,56 @@
           </div>
         </div>
       </div>
+  </div>
+</div>
+
+  <!-- HISTORIAL DE Citas -->
+  <div class="row">
+    <div class="col-12">
+      <div class="card shadow-sm border-0 mb-4">
+        <div class="card-body">
+          <a href="{% url 'crear_cita_paciente' paciente.id %}" class="btn btn-primary mb-3 shadow">
+            <i class="bi bi-calendar-plus"></i> Crear Cita para este paciente
+          </a>
+          <h5 class="mb-3"><i class="bi bi-calendar-event me-2"></i>📅 Historial de Citas</h5>
+          {% if citas %}
+          <div class="table-responsive">
+            <table class="table table-striped table-hover table-bordered shadow-sm table-sm rounded">
+              <thead class="table-light">
+                <tr>
+                  <th>Número de cita</th>
+                  <th>Fecha y hora</th>
+                  <th>Médico asignado</th>
+                  <th>Estado</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for cita in citas %}
+                <tr>
+                  <td>{{ cita.numero_cita }}</td>
+                  <td>{{ cita.fecha_hora|date:"d/m/Y H:i" }}</td>
+                  <td>{{ cita.medico_asignado.get_full_name|default:"-" }}</td>
+                  <td>
+                    <span class="badge {% if cita.estado == 'programada' %}bg-secondary{% elif cita.estado == 'confirmada' %}bg-success{% elif cita.estado == 'cancelada' %}bg-danger{% elif cita.estado == 'no_asistio' %}bg-dark{% elif cita.estado == 'en_espera' %}bg-warning{% elif cita.estado == 'completada' %}bg-info{% else %}bg-secondary{% endif %}">
+                      {{ cita.get_estado_display }}
+                    </span>
+                  </td>
+                  <td class="text-center">
+                    <a href="{% url 'citas_detalle' cita.id %}" class="btn btn-outline-primary btn-sm">
+                      <i class="bi bi-eye"></i> Ver Detalle
+                    </a>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% else %}
+            <div class="alert alert-info">Este paciente no tiene citas registradas.</div>
+          {% endif %}
+        </div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- support fixed-patient mode in `CitaForm`
- allow creating appointments directly for a patient
- expose new route `crear_cita_paciente`
- render patient appointment history with bootstrap styling
- show patient name as read-only when creating fixed appointments

## Testing
- `pytest -q` *(fails: fixture errors)*

------
https://chatgpt.com/codex/tasks/task_e_68843cf7c3e0832485f06b7b963a56ad