### PR TITLE
Improve cancel/delete consult UX

### DIFF
--- a/static/js/consulta_actions.js
+++ b/static/js/consulta_actions.js
@@ -1,0 +1,37 @@
+// Manejo de cancelar y eliminar consulta via AJAX
+
+document.addEventListener('DOMContentLoaded', () => {
+  function handleSubmit(event) {
+    event.preventDefault();
+    const form = event.target;
+    const confirmMsg = form.dataset.confirm;
+    if (confirmMsg && !confirm(confirmMsg)) {
+      return;
+    }
+    const formData = new FormData(form);
+    fetch(form.action, {
+      method: 'POST',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      body: formData,
+      credentials: 'same-origin'
+    })
+      .then(r => r.json())
+      .then(data => {
+        if (data.error) {
+          alert(`⚠️ ${data.error}`);
+        } else if (data.redirect_url) {
+          window.location.href = data.redirect_url;
+        } else {
+          window.location.reload();
+        }
+      })
+      .catch(err => console.error(err));
+  }
+
+  document.querySelectorAll('form.js-consulta-cancelar, form.js-consulta-eliminar')
+    .forEach(form => {
+      form.addEventListener('submit', handleSubmit);
+    });
+});

--- a/templates/PAGES/consultas/consulta_card.html
+++ b/templates/PAGES/consultas/consulta_card.html
@@ -182,7 +182,7 @@
             {% if usuario.rol != 'asistente' %}
               {% if consulta.estado == "espera" or consulta.estado == "en_progreso" %}
                 <li>
-                  <form method="post" action="{% url 'consulta_cancelar' consulta.pk %}" onsubmit="return confirm('¿Estás seguro de eliminar?');">
+                  <form method="post" action="{% url 'consulta_cancelar' consulta.pk %}" class="js-consulta-cancelar" data-confirm="¿Estás seguro de eliminar?">
                     {% csrf_token %}
                     <input type="hidden" name="next" value="{{ request.get_full_path }}">
                     <button class="dropdown-item text-warning">
@@ -194,7 +194,7 @@
 
               {% if consulta.estado != "en_progreso" %}
                 <li>
-                  <form method="post" action="{% url 'consulta_eliminar' consulta.pk %}" onsubmit="return confirm('¿Estás seguro de eliminar?');">
+                  <form method="post" action="{% url 'consulta_eliminar' consulta.pk %}" class="js-consulta-eliminar" data-confirm="¿Estás seguro de eliminar?">
                     {% csrf_token %}
                     <input type="hidden" name="next" value="{{ request.get_full_path }}">
                     <button class="dropdown-item text-danger">

--- a/templates/PAGES/consultas/detalle.html
+++ b/templates/PAGES/consultas/detalle.html
@@ -41,7 +41,7 @@
         </a>
       {% endif %}
       {% if consulta.estado == 'espera' or consulta.estado == 'en_progreso' %}
-      <form method="post" action="{% url 'consulta_cancelar' consulta.pk %}" class="d-inline" onsubmit="return confirm('¿Estás seguro de eliminar?');">
+      <form method="post" action="{% url 'consulta_cancelar' consulta.pk %}" class="d-inline js-consulta-cancelar" data-confirm="¿Estás seguro de eliminar?">
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ volver_a }}">
         <button class="btn btn-warning me-1" type="submit">
@@ -51,7 +51,7 @@
       {% endif %}
 
       {% if consulta.estado != 'en_progreso' %}
-      <form method="post" action="{% url 'consulta_eliminar' consulta.pk %}" class="d-inline" onsubmit="return confirm('¿Estás seguro de eliminar?');">
+      <form method="post" action="{% url 'consulta_eliminar' consulta.pk %}" class="d-inline js-consulta-eliminar" data-confirm="¿Estás seguro de eliminar?">
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ volver_a }}">
         <button class="btn btn-danger me-1" type="submit">

--- a/templates/PAGES/pacientes/detalle.html
+++ b/templates/PAGES/pacientes/detalle.html
@@ -539,7 +539,7 @@
                             {% if c.estado in 'espera,en_progreso' %}
                               <li>
                                 <form action="{% url 'consulta_cancelar' c.pk %}" method="post"
-                                      onsubmit="return confirm('¿Cancelar consulta?');">
+                                      class="js-consulta-cancelar" data-confirm="¿Cancelar consulta?">
                                   {% csrf_token %}
                                   <button class="dropdown-item text-warning">
                                     <i class="bi bi-x-circle me-2"></i>Cancelar
@@ -551,7 +551,7 @@
                             {% if c.estado != 'cancelada' %}
                               <li>
                                 <form action="{% url 'consulta_eliminar' c.pk %}" method="post"
-                                      onsubmit="return confirm('Esta acción es irreversible. ¿Eliminar?');">
+                                      class="js-consulta-eliminar" data-confirm="Esta acción es irreversible. ¿Eliminar?">
                                   {% csrf_token %}
                                   <button class="dropdown-item text-danger">
                                     <i class="bi bi-trash3 me-2"></i>Eliminar

--- a/templates/base.html
+++ b/templates/base.html
@@ -762,7 +762,9 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 });
-    </script>
+</script>
+
+    <script src="{% static 'js/consulta_actions.js' %}"></script>
 
     {% block scripts %}{% endblock %}
     {% block extra_js %}{% endblock %}


### PR DESCRIPTION
## Summary
- return JSON errors for unauthorized cancel/delete requests
- handle cancel/delete forms with JavaScript to show alert without redirect
- add script to base template
- hook new classes in cancel/delete forms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884bfda70e483249247c0f4ea9f3f78