### PR TITLE
Ajustes para citas reprogramadas

### DIFF
--- a/consultorio_API/views.py
+++ b/consultorio_API/views.py
@@ -4619,12 +4619,12 @@ class CitaDetailView(CitaPermisoMixin, DetailView):
         elif user.rol == 'medico':
             return (
                 cita.medico_asignado == user
-                and cita.estado in ['programada', 'confirmada']
+                and cita.estado in ['programada', 'confirmada', 'reprogramada']
             )
         elif user.rol == 'asistente':
             return (
                 cita.consultorio == user.consultorio
-                and cita.estado in ['programada', 'confirmada']
+                and cita.estado in ['programada', 'confirmada', 'reprogramada']
             )
         return False
 

--- a/templates/PAGES/citas/detalle.html
+++ b/templates/PAGES/citas/detalle.html
@@ -589,6 +589,18 @@
                   </span>
                 </div>
               </div>
+
+              {% if cita.cita_anterior %}
+              <div class="info-item d-flex justify-content-between align-items-center">
+                <div>
+                  <div class="info-label">
+                    <i class="bi bi-arrow-counterclockwise"></i>Cita Anterior
+                  </div>
+                  <div class="info-value">{{ cita.cita_anterior.numero_cita }}</div>
+                </div>
+                <a href="{% url 'citas_detalle' cita.cita_anterior.id %}?next={{ request.get_full_path|urlencode }}" class="btn btn-outline-primary btn-sm">Ver Cita</a>
+              </div>
+              {% endif %}
             </div>
           </div>
 
@@ -960,20 +972,6 @@
       </div>
 {% endif %}
 
-        <!-- Información Adicional -->
-        {% if cita.cita_anterior %}
-        <div class="alert alert-info mt-4">
-          <h6 class="alert-heading fw-bold">
-            <i class="bi bi-info-circle me-2"></i>
-            Cita Anterior
-          </h6>
-          <p class="mb-2">
-            Proviene de la cita <strong>{{ cita.cita_anterior.numero_cita }}</strong>
-            ({{ cita.cita_anterior.fecha_hora|date:"d/m/Y H:i" }})
-          </p>
-          <a class="btn btn-sm btn-primary" href="{% url 'citas_detalle' cita.cita_anterior.id %}?next={{ request.get_full_path|urlencode }}">Ver Cita</a>
-        </div>
-        {% endif %}
       </div>
     </div>
   </div>
@@ -1031,7 +1029,16 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         revisar();
         setInterval(revisar, 60000);
-    }
+
+    {% if user.rol == 'asistente' %}
+    const forbiddenForms = document.querySelectorAll("form[action*=cancelar], form[action*=eliminar], form[action*=no-asistio]");
+    forbiddenForms.forEach(f => {
+        f.addEventListener("submit", function(ev){
+            ev.preventDefault();
+            alert("No tienes permiso para cancelar o eliminar citas.");
+        });
+    });
+    {% endif %}
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ampliar `puede_editar_cita` para permitir editar citas reprogramadas
- permitir que doctores cancelen y eliminen citas reprogramadas
- mostrar campo **Cita Anterior** dentro de Información General
- alertar a asistentes si intentan acciones no permitidas en detalle de cita

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-django`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884c193a868832487e49e03563c0a8f