### PR TITLE
Filtrar citas previas por fecha

### DIFF
--- a/consultorio_API/tests/test_citas_previas.py
+++ b/consultorio_API/tests/test_citas_previas.py
@@ -1,0 +1,42 @@
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from consultorio_API.models import Paciente, Cita, Consultorio, Usuario
+
+@pytest.mark.django_db
+def test_ajax_citas_previas_filtra_fecha_hora(client):
+    consultorio = Consultorio.objects.create(nombre="CF")
+    admin = Usuario.objects.create(username="u", rol="admin", is_superuser=True)
+    client.force_login(admin)
+    paciente = Paciente.objects.create(nombre_completo="P", fecha_nacimiento="2000-01-01", sexo="M", telefono="1", correo="p@p.com", direccion="x", consultorio=consultorio)
+    antes = timezone.now() - timezone.timedelta(days=3)
+    middle = timezone.now() - timezone.timedelta(days=1)
+    despues = timezone.now() + timezone.timedelta(days=2)
+    c1 = Cita.objects.create(numero_cita="1", paciente=paciente, consultorio=consultorio, fecha_hora=antes, duracion=30)
+    c2 = Cita.objects.create(numero_cita="2", paciente=paciente, consultorio=consultorio, fecha_hora=middle, duracion=30)
+    Cita.objects.create(numero_cita="3", paciente=paciente, consultorio=consultorio, fecha_hora=despues, duracion=30)
+
+    fecha = (timezone.now() + timezone.timedelta(hours=1)).date().isoformat()
+    url = reverse("ajax_citas_previas")
+    resp = client.get(url, {"paciente_id": paciente.id, "fecha": fecha, "hora": "00:00"})
+    data = resp.json()["citas"]
+    ids = [c["id"] for c in data]
+    assert ids == [str(c1.id), str(c2.id)]
+
+@pytest.mark.django_db
+def test_ajax_citas_previas_solo_fecha(client):
+    consultorio = Consultorio.objects.create(nombre="CF2")
+    admin = Usuario.objects.create(username="u2", rol="admin", is_superuser=True)
+    client.force_login(admin)
+    paciente = Paciente.objects.create(nombre_completo="P2", fecha_nacimiento="2000-01-01", sexo="M", telefono="1", correo="p2@p.com", direccion="x", consultorio=consultorio)
+    antes = timezone.now() - timezone.timedelta(days=5)
+    despues = timezone.now() + timezone.timedelta(days=1)
+    c1 = Cita.objects.create(numero_cita="10", paciente=paciente, consultorio=consultorio, fecha_hora=antes, duracion=30)
+    Cita.objects.create(numero_cita="11", paciente=paciente, consultorio=consultorio, fecha_hora=despues, duracion=30)
+
+    fecha = timezone.now().date().isoformat()
+    url = reverse("ajax_citas_previas")
+    resp = client.get(url, {"paciente_id": paciente.id, "fecha": fecha})
+    data = resp.json()["citas"]
+    assert len(data) == 1
+    assert data[0]["id"] == str(c1.id)

--- a/templates/PAGES/citas/crear.html
+++ b/templates/PAGES/citas/crear.html
@@ -166,15 +166,6 @@
                         <!-- Fecha y Hora -->
                         <div class="form-section">
                             <h6><i class="fas fa-calendar-alt me-2"></i>Fecha y Hora</h6>
-                            <div class="alert alert-info d-flex align-items-start">
-                                <i class="bi bi-info-circle-fill me-2 fs-4"></i>
-                                <div>
-                                    <strong>Información de Horarios</strong><br>
-                                    • Horario de atención: 7:00 AM - 6:00 PM <br>
-                                    • Los horarios se actualizan automáticamente según disponibilidad <br>
-                                    • Solo se muestran horarios disponibles para la duración seleccionada
-                                </div>
-                            </div>
                             <div class="row">
                                 <div class="col-md-4">
                                     <div class="mb-3">
@@ -516,7 +507,12 @@
         $('#id_cita_anterior').html('<option value="">No hay citas anteriores</option>');
         return;
       }
-      $.getJSON('{% url "ajax_citas_previas" %}', {paciente_id: pid})
+      const params = {paciente_id: pid};
+      const f = $('#id_fecha').val();
+      const h = $('#id_hora').val();
+      if(f) params.fecha = f;
+      if(h) params.hora = h;
+      $.getJSON('{% url "ajax_citas_previas" %}', params)
         .done(function(r){
           const $sel = $('#id_cita_anterior');
           $sel.empty();
@@ -528,7 +524,7 @@
           }
         });
     }
-    $('#id_paciente').on('change', cargarCitasPrevias);
+    $('#id_paciente, #id_fecha, #id_hora').on('change', cargarCitasPrevias);
     cargarCitasPrevias();
 
     /* Validación simple al enviar */

--- a/templates/PAGES/citas/editar.html
+++ b/templates/PAGES/citas/editar.html
@@ -235,7 +235,12 @@ $(function(){
       $('#id_cita_anterior').html('<option value="">No hay citas anteriores</option>');
       return;
     }
-    $.getJSON('{% url "ajax_citas_previas" %}',{paciente_id:pid})
+    const params={paciente_id:pid};
+    const f=$('#id_fecha').val();
+    const h=$('#id_hora').val();
+    if(f) params.fecha=f;
+    if(h) params.hora=h;
+    $.getJSON('{% url "ajax_citas_previas" %}',params)
       .done(r=>{
         const $sel=$('#id_cita_anterior');
         $sel.empty();
@@ -247,7 +252,7 @@ $(function(){
         }
       });
   }
-  $('#id_paciente').on('change',cargarCitasPrevias);
+  $('#id_paciente,#id_fecha,#id_hora').on('change',cargarCitasPrevias);
   cargarCitasPrevias();
   $('#citaForm').on('submit',e=>{if(!$h.val()){e.preventDefault();alert('Seleccione una hora disponible.');}});
 


### PR DESCRIPTION
## Summary
- filter previous appointments when only a date is provided
- update AJAX view to support date-only filtering
- add regression tests for `ajax_citas_previas`
- remove schedule info block from appointment creation form

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884bd36c4d883249e29e6d8e36397d5