### PR TITLE
Fix permissions for rescheduled appointments

### DIFF
--- a/consultorio_API/views.py
+++ b/consultorio_API/views.py
@@ -4607,10 +4607,12 @@ class CitaDetailView(CitaPermisoMixin, DetailView):
 
     def _puede_tomar_cita(self, user, cita):
         """Verifica si el médico puede tomar la cita"""
-        return (user.rol == 'medico' and 
-                user.consultorio == cita.consultorio and
-                not cita.medico_asignado and
-                cita.estado in ['programada', 'confirmada'])
+        return (
+            user.rol == 'medico'
+            and user.consultorio == cita.consultorio
+            and not cita.medico_asignado
+            and cita.estado in ['programada', 'confirmada', 'reprogramada']
+        )
 
     def _puede_editar_cita(self, user, cita):
         """Verifica si el usuario puede editar la cita"""

--- a/consultorio_API/viewscitas.py
+++ b/consultorio_API/viewscitas.py
@@ -1318,10 +1318,12 @@ def puede_editar_cita(user, cita):
 
 def puede_tomar_cita(user, cita):
     """Verifica si el médico puede tomar la cita"""
-    return (user.rol == 'medico' and 
-            user.consultorio == cita.consultorio and
-            not cita.medico_asignado and
-            cita.estado in ['programada', 'confirmada'])
+    return (
+        user.rol == 'medico'
+        and user.consultorio == cita.consultorio
+        and not cita.medico_asignado
+        and cita.estado in ['programada', 'confirmada', 'reprogramada']
+    )
 
 
 def get_color_by_estado(estado):

--- a/templates/PAGES/citas/detalle.html
+++ b/templates/PAGES/citas/detalle.html
@@ -885,7 +885,7 @@
             </form>
             {% endif %}
 
-            {% if cita.estado == 'programada' and not consulta or cita.estado == 'confirmada' and not consulta %}
+            {% if not consulta and cita.estado in 'programada confirmada reprogramada' %}
             <form method="post" action="{% url 'cita_marcar_no_asistio' cita.id %}" class="d-inline w-100">
               {% csrf_token %}
               <input type="hidden" name="next" value="{{ volver_a }}">
@@ -1029,6 +1029,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         revisar();
         setInterval(revisar, 60000);
+    }
 
     {% if user.rol == 'asistente' %}
     const forbiddenForms = document.querySelectorAll("form[action*=cancelar], form[action*=eliminar], form[action*=no-asistio]");


### PR DESCRIPTION
## Summary
- allow doctors to take rescheduled appointments in views
- extend `puede_tomar_cita` for `reprogramada` state
- show "No Asistió" for rescheduled appointments
- close javascript block correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884c6e333e08324858f1021c066f1f5