### PR TITLE
Fix assistant permissions for canceled appointments

### DIFF
--- a/consultorio_API/viewscitas.py
+++ b/consultorio_API/viewscitas.py
@@ -343,6 +343,7 @@ def detalle_cita(request, cita_id):
         ),
         'puede_tomar_cita': puede_tomar_cita(request.user, cita),
         'puede_editar': puede_editar_cita(request.user, cita),
+        'puede_reprogramar': puede_reprogramar_cita(request.user, cita),
         'usuario': request.user,
         # Evitar ValueError si USE_TZ=False
         'ahora': timezone.now(),
@@ -359,7 +360,7 @@ def reprogramar_cita(request, cita_id):
     if settings.USE_TZ and timezone.is_naive(cita.fecha_hora):
         cita.fecha_hora = timezone.make_aware(cita.fecha_hora)
 
-    if not puede_editar_cita(request.user, cita):
+    if not puede_reprogramar_cita(request.user, cita):
         messages.error(request, "No tienes permisos para reprogramar esta cita.")
         return redirect_next(request, 'citas_detalle', pk=cita.id)
 
@@ -1295,7 +1296,8 @@ def puede_ver_cita(user, cita):
         # Los médicos pueden acceder al detalle de cualquier cita
         return True
     if user.rol == "asistente":
-        return cita.consultorio == user.consultorio
+        # Los asistentes pueden ver todas las citas
+        return True
     return False
 
 
@@ -1313,6 +1315,17 @@ def puede_editar_cita(user, cita):
             cita.consultorio == user.consultorio
             and cita.estado in ['programada', 'confirmada', 'reprogramada']
         )
+    return False
+
+
+def puede_reprogramar_cita(user, cita):
+    """Verifica si el usuario puede reprogramar la cita"""
+    if puede_editar_cita(user, cita):
+        return True
+    if cita.estado == 'cancelada' and user.rol in ['admin', 'medico', 'asistente']:
+        if user.rol == 'admin':
+            return True
+        return cita.consultorio == user.consultorio
     return False
 
 

--- a/templates/PAGES/citas/detalle.html
+++ b/templates/PAGES/citas/detalle.html
@@ -831,6 +831,12 @@
               Reprogramar
             </a>
             {% endif %}
+            {% if not puede_editar and puede_reprogramar %}
+            <a href="{% url 'reprogramar_cita' cita.id %}?next={{ volver_a|urlencode }}" class="btn btn-action btn-warning">
+              <i class="bi bi-clock-history"></i>
+              Reprogramar
+            </a>
+            {% endif %}
 
             <!-- Liberar Cita -->
             {% if user.rol == 'admin' or cita.medico_asignado == user %}
@@ -922,6 +928,12 @@
               <i class="bi bi-pencil-square"></i>
               Editar Cita
             </a>
+            <a href="{% url 'reprogramar_cita' cita.id %}?next={{ volver_a|urlencode }}" class="btn btn-action btn-warning">
+              <i class="bi bi-clock-history"></i>
+              Reprogramar
+            </a>
+            {% endif %}
+            {% if not puede_editar and puede_reprogramar %}
             <a href="{% url 'reprogramar_cita' cita.id %}?next={{ volver_a|urlencode }}" class="btn btn-action btn-warning">
               <i class="bi bi-clock-history"></i>
               Reprogramar


### PR DESCRIPTION
## Summary
- allow assistants to view any appointment
- add permission helper to reprogram canceled appointments
- show the reprogram button on canceled appointments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884c970d9348324a437b92c8aad6cf0