### PR TITLE
Fix assistant permissions for canceled appointments

### DIFF
--- a/consultorio_API/views.py
+++ b/consultorio_API/views.py
@@ -1691,7 +1691,8 @@ def puede_ver_cita(user, cita):
         # Los médicos pueden acceder al detalle de cualquier cita
         return True
     if user.rol == "asistente":
-        return cita.consultorio == user.consultorio
+        # Los asistentes ahora pueden ver todas las citas
+        return True
     return False
 
 
@@ -1709,6 +1710,15 @@ def puede_editar_cita(user, cita):
             cita.consultorio == user.consultorio
             and cita.estado in ['programada', 'confirmada']
         )
+    return False
+
+
+def puede_reprogramar_cita(user, cita):
+    """Permite reprogramar citas canceladas"""
+    if user.rol == 'admin':
+        return True
+    if user.rol in ['medico', 'asistente'] and cita.estado == 'cancelada':
+        return True
     return False
 
 
@@ -4566,8 +4576,8 @@ class CitaDetailView(CitaPermisoMixin, DetailView):
             # Los médicos autenticados pueden ver cualquier cita
             return True
         if user.rol == "asistente":
-            # Los asistentes mantienen la restricción por consultorio
-            return cita.consultorio == user.consultorio
+            # Los asistentes pueden ver todas las citas
+            return True
 
         return False
 
@@ -4593,6 +4603,7 @@ class CitaDetailView(CitaPermisoMixin, DetailView):
                                    user.rol in ['admin', 'asistente']),
             'puede_tomar_cita': self._puede_tomar_cita(user, cita),
             'puede_editar': self._puede_editar_cita(user, cita),
+            'puede_reprogramar': self._puede_reprogramar_cita(user, cita),
             'usuario': user,
             'now': timezone.now(),
         })
@@ -4626,6 +4637,14 @@ class CitaDetailView(CitaPermisoMixin, DetailView):
                 cita.consultorio == user.consultorio
                 and cita.estado in ['programada', 'confirmada', 'reprogramada']
             )
+        return False
+
+    def _puede_reprogramar_cita(self, user, cita):
+        """Permite reprogramar citas canceladas"""
+        if user.rol == 'admin':
+            return True
+        if user.rol in ['medico', 'asistente'] and cita.estado == 'cancelada':
+            return True
         return False
 
 

--- a/consultorio_API/viewscitas.py
+++ b/consultorio_API/viewscitas.py
@@ -343,6 +343,7 @@ def detalle_cita(request, cita_id):
         ),
         'puede_tomar_cita': puede_tomar_cita(request.user, cita),
         'puede_editar': puede_editar_cita(request.user, cita),
+        'puede_reprogramar': puede_reprogramar_cita(request.user, cita),
         'usuario': request.user,
         # Evitar ValueError si USE_TZ=False
         'ahora': timezone.now(),
@@ -359,7 +360,7 @@ def reprogramar_cita(request, cita_id):
     if settings.USE_TZ and timezone.is_naive(cita.fecha_hora):
         cita.fecha_hora = timezone.make_aware(cita.fecha_hora)
 
-    if not puede_editar_cita(request.user, cita):
+    if not puede_reprogramar_cita(request.user, cita):
         messages.error(request, "No tienes permisos para reprogramar esta cita.")
         return redirect_next(request, 'citas_detalle', pk=cita.id)
 
@@ -1295,7 +1296,8 @@ def puede_ver_cita(user, cita):
         # Los médicos pueden acceder al detalle de cualquier cita
         return True
     if user.rol == "asistente":
-        return cita.consultorio == user.consultorio
+        # Los asistentes pueden ver todas las citas
+        return True
     return False
 
 
@@ -1313,6 +1315,15 @@ def puede_editar_cita(user, cita):
             cita.consultorio == user.consultorio
             and cita.estado in ['programada', 'confirmada', 'reprogramada']
         )
+    return False
+
+
+def puede_reprogramar_cita(user, cita):
+    """Permite reprogramar citas canceladas"""
+    if user.rol == 'admin':
+        return True
+    if user.rol in ['medico', 'asistente'] and cita.estado == 'cancelada':
+        return True
     return False
 
 

--- a/templates/PAGES/citas/detalle.html
+++ b/templates/PAGES/citas/detalle.html
@@ -831,6 +831,12 @@
               Reprogramar
             </a>
             {% endif %}
+            {% if not puede_editar and puede_reprogramar %}
+            <a href="{% url 'reprogramar_cita' cita.id %}?next={{ volver_a|urlencode }}" class="btn btn-action btn-warning">
+              <i class="bi bi-clock-history"></i>
+              Reprogramar
+            </a>
+            {% endif %}
 
             <!-- Liberar Cita -->
             {% if user.rol == 'admin' or cita.medico_asignado == user %}
@@ -922,6 +928,12 @@
               <i class="bi bi-pencil-square"></i>
               Editar Cita
             </a>
+            <a href="{% url 'reprogramar_cita' cita.id %}?next={{ volver_a|urlencode }}" class="btn btn-action btn-warning">
+              <i class="bi bi-clock-history"></i>
+              Reprogramar
+            </a>
+            {% endif %}
+            {% if not puede_editar and puede_reprogramar %}
             <a href="{% url 'reprogramar_cita' cita.id %}?next={{ volver_a|urlencode }}" class="btn btn-action btn-warning">
               <i class="bi bi-clock-history"></i>
               Reprogramar


### PR DESCRIPTION
## Summary
- allow assistants to view any appointment
- add permission helper to reprogram canceled appointments
- show the reprogram button on canceled appointments
- doctors and assistants can only reprogram cancelled appointments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6884c970d9348324a437b92c8aad6cf0