### PR TITLE
Restringir eliminación de consultas a administradores

### DIFF
--- a/consultorio_API/views_consultas.py
+++ b/consultorio_API/views_consultas.py
@@ -62,10 +62,10 @@ def eliminar_consulta(request, pk):
     """Eliminar una consulta si el usuario tiene permisos."""
     ajax = request.headers.get("x-requested-with") == "XMLHttpRequest"
 
-    if request.user.rol == "asistente":
+    if request.user.rol != "admin":
         if ajax:
             return JsonResponse(
-                {"error": "No tienes permiso para cancelar consultas."},
+                {"error": "No tienes permiso para eliminar consultas."},
                 status=403,
             )
         messages.error(request, "No puedes eliminar consultas.")

--- a/templates/PAGES/consultas/consulta_card.html
+++ b/templates/PAGES/consultas/consulta_card.html
@@ -192,7 +192,7 @@
                 </li>
               {% endif %}
 
-              {% if consulta.estado != "en_progreso" %}
+              {% if usuario.rol == 'admin' and consulta.estado != "en_progreso" %}
                 <li>
                   <form method="post" action="{% url 'consulta_eliminar' consulta.pk %}" class="js-consulta-eliminar" data-confirm="¿Estás seguro de eliminar?">
                     {% csrf_token %}

--- a/templates/PAGES/consultas/detalle.html
+++ b/templates/PAGES/consultas/detalle.html
@@ -50,7 +50,7 @@
       </form>
       {% endif %}
 
-      {% if consulta.estado != 'en_progreso' %}
+      {% if usuario.rol == 'admin' and consulta.estado != 'en_progreso' %}
       <form method="post" action="{% url 'consulta_eliminar' consulta.pk %}" class="d-inline js-consulta-eliminar" data-confirm="¿Estás seguro de eliminar?">
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ volver_a }}">


### PR DESCRIPTION
## Summary
- Impide que los médicos eliminen consultas desde el backend
- Oculta la opción de eliminar consulta en las vistas de lista y detalle para usuarios médicos

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68930f9c53c88324827f394b539bca6d