### PR TITLE
Ensure MedicamentoCatalogo fields exist

### DIFF
--- a/consultorio_API/migrations/0002_ensure_catalog_fields.py
+++ b/consultorio_API/migrations/0002_ensure_catalog_fields.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('consultorio_API', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE consultorio_API_medicamentocatalogo ADD COLUMN IF NOT EXISTS nombre varchar(255) NOT NULL",
+                    reverse_sql="ALTER TABLE consultorio_API_medicamentocatalogo DROP COLUMN IF EXISTS nombre",
+                ),
+                migrations.RunSQL(
+                    sql="ALTER TABLE consultorio_API_medicamentocatalogo ADD COLUMN IF NOT EXISTS codigo_barras varchar(50) NOT NULL UNIQUE",
+                    reverse_sql="ALTER TABLE consultorio_API_medicamentocatalogo DROP COLUMN IF EXISTS codigo_barras",
+                ),
+                migrations.RunSQL(
+                    sql="ALTER TABLE consultorio_API_medicamentocatalogo ADD COLUMN IF NOT EXISTS existencia integer UNSIGNED NOT NULL DEFAULT 0",
+                    reverse_sql="ALTER TABLE consultorio_API_medicamentocatalogo DROP COLUMN IF EXISTS existencia",
+                ),
+                migrations.RunSQL(
+                    sql="ALTER TABLE consultorio_API_medicamentocatalogo ADD COLUMN IF NOT EXISTS departamento varchar(100) NULL",
+                    reverse_sql="ALTER TABLE consultorio_API_medicamentocatalogo DROP COLUMN IF EXISTS departamento",
+                ),
+                migrations.RunSQL(
+                    sql="ALTER TABLE consultorio_API_medicamentocatalogo ADD COLUMN IF NOT EXISTS precio decimal(10,2) NULL",
+                    reverse_sql="ALTER TABLE consultorio_API_medicamentocatalogo DROP COLUMN IF EXISTS precio",
+                ),
+                migrations.RunSQL(
+                    sql="ALTER TABLE consultorio_API_medicamentocatalogo ADD COLUMN IF NOT EXISTS categoria varchar(100) NULL",
+                    reverse_sql="ALTER TABLE consultorio_API_medicamentocatalogo DROP COLUMN IF EXISTS categoria",
+                ),
+                migrations.RunSQL(
+                    sql="ALTER TABLE consultorio_API_medicamentocatalogo ADD COLUMN IF NOT EXISTS imagen varchar(100) NULL",
+                    reverse_sql="ALTER TABLE consultorio_API_medicamentocatalogo DROP COLUMN IF EXISTS imagen",
+                ),
+            ],
+        ),
+    ]


### PR DESCRIPTION
## Summary
- add migration that conditionally creates all MedicamentoCatalogo fields

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a825fd1a4c83248ceaab82a1653243