### PR TITLE
feat: include medication instructions in receta PDF

### DIFF
--- a/consultorio_API/pdf/receta_reportlab.py
+++ b/consultorio_API/pdf/receta_reportlab.py
@@ -274,52 +274,62 @@ def build_receta_pdf(buffer, receta):
             page_meds = meds[start_idx:end_idx]
             
             for m in page_meds:
-                # Crear bloque individual para cada medicamento
+                # Bloque individual para cada medicamento
                 bc = _barcode_flowable(getattr(m, "codigo_barras", ""))
-                
-                if bc:
-                    med_row = [
-                        Paragraph(f"<b>{_fmt(m.nombre)}</b>", styles["TXT"]),
-                        Paragraph(f"Cantidad: {_fmt(m.cantidad)}", styles["TXT"]),
-                        bc
-                    ]
-                    
-                    med_table = Table(
-                        [med_row],
-                        colWidths=[70*mm, 35*mm, 40*mm],
-                        style=TableStyle([
-                            ("BOX", (0,0), (-1,-1), 1, colors.HexColor("#dee2e6")),
-                            ("BACKGROUND", (0,0), (-1,-1), colors.HexColor("#f8f9fa")),
-                            ("LEFTPADDING", (0,0), (-1,-1), 4),   # Reducir padding
-                            ("RIGHTPADDING", (0,0), (-1,-1), 4),  # Reducir padding
-                            ("TOPPADDING", (0,0), (-1,-1), 3),    # Reducir padding
-                            ("BOTTOMPADDING", (0,0), (-1,-1), 3), # Reducir padding
-                            ("VALIGN", (0,0), (-1,-1), "MIDDLE"),
-                            ("ALIGN", (2,0), (2,0), "CENTER"),  # Centrar código de barras
-                        ])
-                    )
-                else:
-                    # Si no hay código de barras, solo mostrar nombre y cantidad
-                    med_row = [
-                        Paragraph(f"<b>{_fmt(m.nombre)}</b>", styles["TXT"]),
-                        Paragraph(f"Cantidad: {_fmt(m.cantidad)}", styles["TXT"])
-                    ]
-                    
-                    med_table = Table(
-                        [med_row],
-                        colWidths=[70*mm, 75*mm],
-                        style=TableStyle([
-                            ("BOX", (0,0), (-1,-1), 1, colors.HexColor("#dee2e6")),
-                            ("BACKGROUND", (0,0), (-1,-1), colors.HexColor("#f8f9fa")),
-                            ("LEFTPADDING", (0,0), (-1,-1), 4),   # Reducir padding
-                            ("RIGHTPADDING", (0,0), (-1,-1), 4),  # Reducir padding
-                            ("TOPPADDING", (0,0), (-1,-1), 3),    # Reducir padding
-                            ("BOTTOMPADDING", (0,0), (-1,-1), 3), # Reducir padding
-                            ("VALIGN", (0,0), (-1,-1), "MIDDLE"),
-                        ])
-                    )
-                
-                story += [med_table, Spacer(1, 1*mm)]  # Reducir espaciado entre medicamentos
+
+                # Recuadro con indicaciones del medicamento
+                indicaciones = []
+                for label, attr in [
+                    ("Dosis", "dosis"),
+                    ("Frecuencia", "frecuencia"),
+                    ("Vía de administración", "via_administracion"),
+                    ("Duración", "duracion"),
+                ]:
+                    val = getattr(m, attr, None)
+                    if val:
+                        indicaciones.append(Paragraph(f"{label}: {_fmt(val)}", styles["SM"]))
+
+                extra = getattr(m, "indicaciones_especificas", None)
+                if extra:
+                    indicaciones.append(Paragraph(f"Indicaciones específicas: {_fmt(extra)}", styles["SM"]))
+
+                if not indicaciones:
+                    indicaciones.append(Paragraph("", styles["SM"]))
+
+                ind_table = Table(
+                    [[p] for p in indicaciones],
+                    colWidths=[None],
+                    style=TableStyle([
+                        ("BACKGROUND", (0,0), (-1,-1), colors.HexColor("#f8f9fa")),
+                        ("BOX", (0,0), (-1,-1), 0.5, colors.HexColor("#dee2e6")),
+                        ("LEFTPADDING", (0,0), (-1,-1), 4),
+                        ("RIGHTPADDING", (0,0), (-1,-1), 4),
+                        ("TOPPADDING", (0,0), (-1,-1), 2),
+                        ("BOTTOMPADDING", (0,0), (-1,-1), 2),
+                    ])
+                )
+
+                rows = [
+                    [Paragraph(f"<b>{_fmt(m.nombre)}</b>", styles["TXT"]), bc or ""],
+                    [Paragraph(f"Cantidad: {_fmt(m.cantidad)}", styles["TXT"]), ""],
+                    [ind_table, ""],
+                ]
+
+                med_table = Table(
+                    rows,
+                    colWidths=[120*mm, 40*mm],
+                    style=TableStyle([
+                        ("SPAN", (0,2), (1,2)),
+                        ("VALIGN", (0,0), (-1,-1), "TOP"),
+                        ("ALIGN", (1,0), (1,0), "RIGHT"),
+                        ("LEFTPADDING", (0,0), (-1,-1), 2),
+                        ("RIGHTPADDING", (0,0), (-1,-1), 2),
+                        ("TOPPADDING", (0,0), (-1,-1), 2),
+                        ("BOTTOMPADDING", (0,0), (-1,-1), 2),
+                    ])
+                )
+
+                story += [med_table, Spacer(1, 2*mm)]
 
     # QR + folio/fecha en una fila (solo en la última página o primera si no hay medicamentos)
     folio = f"Folio: {receta.pk}"

--- a/consultorio_API/views_recetas.py
+++ b/consultorio_API/views_recetas.py
@@ -135,6 +135,11 @@ def receta_catalogo_excel_agregar(request, receta_id):
     receta = get_object_or_404(Receta, id=receta_id)
     nombre = (request.POST.get("nombre") or "").strip()
     clave = (request.POST.get("clave") or "").strip()
+    dosis = (request.POST.get("dosis") or "").strip()
+    frecuencia = (request.POST.get("frecuencia") or "").strip()
+    via_administracion = (request.POST.get("via_administracion") or "").strip()
+    duracion = (request.POST.get("duracion") or "").strip()
+    indicaciones_especificas = (request.POST.get("indicaciones_especificas") or "").strip()
     try:
         cantidad = int(request.POST.get("cantidad") or "1")
     except Exception:
@@ -164,6 +169,16 @@ def receta_catalogo_excel_agregar(request, receta_id):
 
     if mr:
         mr.cantidad += cantidad
+        if dosis:
+            mr.dosis = dosis
+        if frecuencia:
+            mr.frecuencia = frecuencia
+        if via_administracion:
+            mr.via_administracion = via_administracion
+        if duracion:
+            mr.duracion = duracion
+        if indicaciones_especificas:
+            mr.indicaciones_especificas = indicaciones_especificas
         if not mr.codigo_barras and clave:
             mr.codigo_barras = clave
         if cat:
@@ -176,6 +191,11 @@ def receta_catalogo_excel_agregar(request, receta_id):
             receta=receta,
             nombre=cat_nombre,
             cantidad=cantidad,
+            dosis=dosis,
+            frecuencia=frecuencia,
+            via_administracion=via_administracion or None,
+            duracion=duracion,
+            indicaciones_especificas=indicaciones_especificas or None,
             existencia=cat.get("existencia", 0) if cat else 0,
             codigo_barras=cat.get("clave") if cat else (clave or None),
             categoria=cat.get("categoria") if cat else None,
@@ -190,6 +210,11 @@ def receta_catalogo_excel_agregar(request, receta_id):
             "cantidad": mr.cantidad,
             "codigo_barras": mr.codigo_barras or "",
             "principio_activo": mr.principio_activo or "",
+            "dosis": mr.dosis,
+            "frecuencia": mr.frecuencia,
+            "via_administracion": mr.via_administracion or "",
+            "duracion": mr.duracion,
+            "indicaciones_especificas": mr.indicaciones_especificas or "",
         }
     )
 
@@ -206,6 +231,11 @@ def receta_medicamentos_json(request, receta_id):
             "principio_activo": mr.principio_activo or "",
             "cantidad": mr.cantidad,
             "codigo_barras": mr.codigo_barras or "",
+            "dosis": mr.dosis,
+            "frecuencia": mr.frecuencia,
+            "via_administracion": mr.via_administracion or "",
+            "duracion": mr.duracion,
+            "indicaciones_especificas": mr.indicaciones_especificas or "",
         }
         for mr in receta.medicamentos.all()
     ]


### PR DESCRIPTION
## Summary
- add shaded instruction box per medication in receta PDF
- capture dosage details when adding catalog medications

## Testing
- `pytest` *(fails: fixture 'client' not found, 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b777ae36f883248ae387ecfeadf87a